### PR TITLE
Transpile ES6 with Babel.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+    "presets": [
+        "@babel/preset-env"
+    ],
+    "plugins": [
+        "@babel/plugin-transform-runtime",
+        "@babel/plugin-proposal-class-properties"
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 **.swp
 **.swo
 .DS_Store
+lib/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "mocha --timeout 10000",
     "js:lint": "eslint .",
     "build": "babel src --out-dir lib",
+    "preinstall": "npm run build",
     "js:lint:fix": "eslint --fix ."
   },
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "mocha --timeout 10000",
     "js:lint": "eslint .",
+    "build": "babel src --out-dir lib",
     "js:lint:fix": "eslint --fix ."
   },
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
@@ -21,6 +22,16 @@
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.4",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.8.3",
+    "@babel/preset-env": "^7.8.4",
+    "@babel/preset-typescript": "^7.8.3",
+    "@babel/register": "^7.8.3",
+    "@babel/runtime": "^7.8.4",
+    "babel-loader": "^8.0.6",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "eslint-config-keep": "git+https://github.com/keep-network/eslint-config-keep.git#0.2.0",

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -37,7 +37,7 @@ const VendingMachineContract = TruffleContract(VendingMachineJSON)
 const ECDSAKeepContract = TruffleContract(ECDSAKeepJSON)
 
 // TODO Need this configured via TBTC.
-const electrumConfig = JSON.parse(fs.readFileSync("./src/electrum-config.json"))
+const electrumConfig = require(__dirname + "/../src/electrum-config.json")
 
 export class DepositFactory {
     config/*: TBTCConfig*/;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+export default require('./TBTC')


### PR DESCRIPTION
Two fixes to get tbtc.js working within a dApp context:

 1. Transpiling the ES6 syntax. We're using a not-so-ubiquitous construct of class members (see below; as for why it's a special case, don't ask me) which needs some transpilation to work with eg. react-scripts

```
| class TBTC {
>     config/*: TBTCConfig*/;
|
|     constructor(config/*: TBTCConfig*/ = defaultConfig, networkMatchCheck = true) {
```

 2. Fix a line where we do a readFile.