### PR TITLE
Remove "Redeem deposit" step from the demo

### DIFF
--- a/example.js
+++ b/example.js
@@ -59,17 +59,6 @@ async function runExample() {
                     console.log(`Minted ${tbtc} TBTC!`)
                     // or
                     // (await deposit.getTDT()).transfer(someLuckyContract)
-
-                    console.log("You have 10s before I redeem this sucker...")
-
-                    // later…
-                    setTimeout(async () => {
-                        console.log("Redeeming deposit :sunglasses:")
-                        (await deposit.requestRedemption("tb....")).autoSubmit()
-                            .onWithdrawn((txHash) => {
-                            // all done!
-                            })
-                    }, 10000)
                 } catch (error) {
                     reject(error)
                 }


### PR DESCRIPTION
It's easy to miss this step if you leave the script running in the
background i.e. waiting for btc tx confirmations, besides redemption can
now be done separately with bin/tbtc.js