### PR TITLE
Typing Day: Deep pass at JSDoc-ing types

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,8 @@ import EthereumHelpers from './src/EthereumHelpers.js';
 
 export { BitcoinHelpers, EthereumHelpers }
 
+/** @typedef { import("./src/Deposit.js").default } Deposit */
+/** @typedef { import("./src/Redemption.js").default } Redemption */
+/** @typedef { import("./src/TBTC.js").TBTC } TBTC */
+
 export default TBTC

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "es6",
+    "target": "es6"
+  },
+  "checkJs": true,
+  "exclude": ["node_modules"]
+}

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -136,12 +136,13 @@ const BitcoinHelpers = {
     },
     /**
      *
-     * @param {(ElectrumClient)=>Promise<any>} block A function to execute with
+     * @param {(ElectrumClient)=>Promise<T>} block A function to execute with
      *        the ElectrumClient passed in; it is expected to return a Promise
      *        that will resolve once the function is finished performing work
      *        with the client. withElectrumClient returns that promise, but also
      *        ensures that the client will be closed once the promise completes
      *        (successfully or unsuccessfully).
+     * @template T
      */
     withElectrumClient: async function(block) {
         const electrumClient = new ElectrumClient(BitcoinHelpers.electrumConfig.testnetWS)
@@ -248,7 +249,7 @@ const BitcoinHelpers = {
          * Watches the Bitcoin chain until the given `transaction` has the given
          * number of `requiredConfirmations`.
          *
-         * @param {Transaction} transaction Transaction object from Electrum.
+         * @param {FoundTransaction} transaction Transaction object from Electrum.
          * @param {number} requiredConfirmations The number of required
          *        confirmations to wait before returning.
          *

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -66,7 +66,7 @@ export class DepositFactory {
      * @return {Promise<BN[]>} A list of the available lot sizes, in satoshis,
      *         as BN instances.
      */
-    async availableSatoshiLotSizes()/*: Promise<BN[]>*/ {
+    async availableSatoshiLotSizes() {
         return await this.systemContract.getAllowedLotSizes()
     }
 
@@ -83,7 +83,7 @@ export class DepositFactory {
      * 
      * @return {Promise<Deposit>} The new deposit with the given lot size.
      */
-    async withSatoshiLotSize(satoshiLotSize/*: BN*/)/*: Promise<Deposit>*/ {
+    async withSatoshiLotSize(satoshiLotSize) {
         if (! await this.systemContract.isAllowedLotSize(satoshiLotSize)) {
             throw new Error(
                 `Lot size ${satoshiLotSize} is not permitted; only ` +

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1,8 +1,10 @@
 import BitcoinHelpers from "./BitcoinHelpers.js"
+/** @typedef { import("./BitcoinHelpers.js").FoundTransaction } BitcoinTransaction */
 
 import EthereumHelpers from "./EthereumHelpers.js"
 
-import TruffleContract from "@truffle/contract"
+import TruffleContract from '@truffle/contract'
+/** @typedef { import("@truffle/contract").default.Contract } TruffleContract */
 
 import Redemption from "./Redemption.js"
 
@@ -10,36 +12,40 @@ import TBTCConstantsJSON from "@keep-network/tbtc/artifacts/TBTCConstants.json"
 import TBTCSystemJSON from "@keep-network/tbtc/artifacts/TBTCSystem.json"
 import TBTCDepositTokenJSON from "@keep-network/tbtc/artifacts/TBTCDepositToken.json"
 import DepositJSON from "@keep-network/tbtc/artifacts/Deposit.json"
-import DepositLogJSON from "@keep-network/tbtc/artifacts/DepositLog.json"
 import DepositFactoryJSON from "@keep-network/tbtc/artifacts/DepositFactory.json"
 import TBTCTokenJSON from "@keep-network/tbtc/artifacts/TBTCToken.json"
 import FeeRebateTokenJSON from "@keep-network/tbtc/artifacts/FeeRebateToken.json"
 import VendingMachineJSON from "@keep-network/tbtc/artifacts/VendingMachine.json"
 import ECDSAKeepJSON from "@keep-network/tbtc/artifacts/ECDSAKeep.json"
+/** @type TruffleContract */
 const TBTCConstants = TruffleContract(TBTCConstantsJSON)
+/** @type TruffleContract */
 const TBTCSystemContract = TruffleContract(TBTCSystemJSON)
+/** @type TruffleContract */
 const TBTCDepositTokenContract = TruffleContract(TBTCDepositTokenJSON)
+/** @type TruffleContract */
 const DepositContract = TruffleContract(DepositJSON)
+/** @type TruffleContract */
 const DepositFactoryContract = TruffleContract(DepositFactoryJSON)
+/** @type TruffleContract */
 const TBTCTokenContract = TruffleContract(TBTCTokenJSON)
+/** @type TruffleContract */
 const FeeRebateTokenContract = TruffleContract(FeeRebateTokenJSON)
+/** @type TruffleContract */
 const VendingMachineContract = TruffleContract(VendingMachineJSON)
+/** @type TruffleContract */
 const ECDSAKeepContract = TruffleContract(ECDSAKeepJSON)
+    
+/** @typedef { import("bn.js") } BN */
+/** @typedef { import("./TBTC").TBTCConfig } TBTCConfig */
 
 export class DepositFactory {
-    // config/*: TBTCConfig*/;
-
-    // constantsContract/*: any */;
-    // systemContract/*: any*/;
-    // tokenContract/*: any */;
-    // depositTokenContract/*: any*/;
-    // feeRebateTokenContract/*: any */;
-    // depositContract/*: any*/;
-    // depositLogContract/*: any*/;
-    // depositFactoryContract/*: any */;
-    // vendingMachineContract/*: any */;
-
-    static async withConfig(config/*: TBTCConfig)*/)/*: Promise<DepositFactory>*/ {
+    /**
+     * Returns a fully-initialized DepositFactory for the given config.
+     *
+     * @param {TBTCConfig} config The config to use for this factory.
+     */
+    static async withConfig(config) {
         const statics = new DepositFactory(config)
         await statics.resolveContracts()
 
@@ -48,10 +54,18 @@ export class DepositFactory {
         return statics
     }
 
-    constructor(config/*: TBTCConfig*/) {
+    /**
+     * @param {TBTCConfig} config The config to use for this factory.
+     */
+    constructor(config) {
+        /** @package */
         this.config = config
     }
 
+    /**
+     * @return {Promise<BN[]>} A list of the available lot sizes, in satoshis,
+     *         as BN instances.
+     */
     async availableSatoshiLotSizes()/*: Promise<BN[]>*/ {
         return await this.systemContract.getAllowedLotSizes()
     }
@@ -64,8 +78,10 @@ export class DepositFactory {
      * 
      * To follow along once the deposit is initialized, see the `Deposit` API.
      * 
-     * @param satoshiLotSize The lot size, in satoshis, of the deposit. Must be
-     *        in the list of allowed lot sizes from Deposit.availableLotSizes().
+     * @param {BN} satoshiLotSize The lot size, in satoshis, of the deposit.
+     *        Must be in the list of allowed lot sizes from `availableLotSizes`.
+     * 
+     * @return {Promise<Deposit>} The new deposit with the given lot size.
      */
     async withSatoshiLotSize(satoshiLotSize/*: BN*/)/*: Promise<Deposit>*/ {
         if (! await this.systemContract.isAllowedLotSize(satoshiLotSize)) {
@@ -80,11 +96,20 @@ export class DepositFactory {
         return deposit
     }
 
+    /**
+     * Looks up an existing deposit at the specified address, and returns a
+     * tbtc.js Deposit wrapper for it.
+     * 
+     * @param {string} depositAddress The address of the deposit to resolve.
+     * 
+     * @return {Promise<Deposit>} The deposit at the given address.
+     */
     async withAddress(depositAddress) {
         return await Deposit.forAddress(this, depositAddress)
     }
 
     // Await the deployed() functions of all contract dependencies.
+    /** @private */
     async resolveContracts() {
         const init = ([contract, propertyName]) => {
             contract.setProvider(this.config.web3.currentProvider)
@@ -102,16 +127,66 @@ export class DepositFactory {
             [VendingMachineContract, 'vendingMachineContract'],
         ]
 
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.constantsContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.systemContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.tokenContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.depositTokenContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.feeRebateTokenContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.depositContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.depositLogContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.depositFactoryContract;
+        /**
+         * @package
+         * @type TruffleContract
+         */
+        this.vendingMachineContract;
+
         await Promise.all(contracts.map(init))
     }
 
     /**
+     * @private
+     * 
      * INTERNAL USE ONLY
      *
      * Initializes a new deposit and returns a tuple of the deposit contract
      * address and the associated keep address.
+     * 
+     * @param {BN} lotSize The lot size to use, in satoshis.
      */
-    async createNewDepositContract(lotSize/*: BN */) {
+    async createNewDepositContract(lotSize) {
         const funderBondAmount = await this.constantsContract.getFunderBondAmount()
         const accountBalance = await this.config.web3.eth.getBalance(this.config.web3.eth.defaultAccount)
         if (funderBondAmount.lt(accountBalance)) {
@@ -155,9 +230,9 @@ export class DepositFactory {
 }
 
 // Bitcoin address handlers are given the deposit's Bitcoin address.
-// type BitcoinAddressHandler = (address: string)=>void)=>void
+/** @typedef {(address: string)=>void} BitcoinAddressHandler */
 // Active handlers are given the deposit that just entered the ACTIVE state.
-// type ActiveHandler = (deposit: Deposit)=>void
+/** @typedef {(deposit: Deposit)=>void} ActiveHandler */
 
 export default class Deposit {
     // factory/*: DepositFactory*/;
@@ -168,7 +243,11 @@ export default class Deposit {
     // bitcoinAddress/*: Promise<string>*/;
     // activeStatePromise/*: Promise<[]>*/; // fulfilled when deposit goes active
 
-    static async forLotSize(factory/*: DepositFactory*/, satoshiLotSize/*: BN*/)/*: Promise<Deposit>*/ {
+    /**
+     * @param {DepositFactory} factory 
+     * @param {BN} satoshiLotSize 
+     */
+    static async forLotSize(factory, satoshiLotSize) {
         console.debug(
             'Creating new deposit contract with lot size',
             satoshiLotSize.toNumber(),
@@ -187,7 +266,11 @@ export default class Deposit {
         return new Deposit(factory, contract, keepContract)
     }
 
-    static async forAddress(factory/*: DepositFactory*/, address/*: string*/)/*: Promise<Deposit>*/ {
+    /**
+     * @param {DepositFactory} factory 
+     * @param {string} address
+     */
+    static async forAddress(factory, address) {
         console.debug(`Looking up Deposit contract at address ${address}...`)
         const contract = await DepositContract.at(address)
 
@@ -210,16 +293,26 @@ export default class Deposit {
         return new Deposit(factory, contract, keepContract)
     }
 
-    static async forTDT(factory/*: DepositFactory*/, tdt/*: TBTCDepositToken | string*/)/*: Promise<Deposit>*/ {
+    /**
+     * @param {DepositFactory} factory 
+     * @param {any | string} tdt
+     */
+    static async forTDT(factory, tdt) {
         return new Deposit(factory, "")
     }
 
-    constructor(factory/*: DepositFactory*/, depositContract/*: TruffleContract*/, keepContract/*: TruffleContract */) {
+    /**
+     * @param {DepositFactory} factory 
+     * @param {TruffleContract} depositContract
+     * @param {TruffleContract} keepContract
+     */
+    constructor(factory, depositContract, keepContract) {
         if (! keepContract) {
             throw "Keep contract required for Deposit instantiation."
         }
 
         this.factory = factory
+        /** @type {string} */
         this.address = depositContract.address
         this.keepContract = keepContract
         this.contract = depositContract
@@ -273,12 +366,12 @@ export default class Deposit {
      * for this deposit. The handler receives the deposit signer wallet's
      * address.
      * 
-     * @param bitcoinAddressHandler A function that takes a bitcoin address
-     *        corresponding to this deposit's signer wallet. Note that
-     *        exceptions in this handler are not managed, so the handler itself
-     *        should deal with its own failure possibilities.
+     * @param {BitcoinAddressHandler} bitcoinAddressHandler A function that
+     *        takes a bitcoin address corresponding to this deposit's signer
+     *        wallet. Note that exceptions in this handler are not managed, so
+     *        the handler itself should deal with its own failure possibilities.
      */
-    onBitcoinAddressAvailable(bitcoinAddressHandler/*: BitcoinAddressHandler*/) {
+    onBitcoinAddressAvailable(bitcoinAddressHandler) {
         this.bitcoinAddress.then(bitcoinAddressHandler)
     }
 
@@ -287,12 +380,13 @@ export default class Deposit {
      * state, when it has been proven funded and becomes eligible for TBTC
      * minting and other uses. The deposit itself is passed to the handler.
      * 
-     * @param activeHandler A handler called when this deposit enters the ACTIVE
-     *        state; receives the deposit as its only parameter. Note that
-     *        exceptions in this handler are not managed, so the handler itself
-     *        should deal with its own failure possibilities.
+     * @param {ActiveHandler} activeHandler A handler called when this deposit
+     *        enters the ACTIVE state; receives the deposit as its only
+     *        parameter. Note that exceptions in this handler are not managed,
+     *        so the handler itself should deal with its own failure
+     *        possibilities.
      */
-    onActive(activeHandler/*: (Deposit)=>void*/) {
+    onActive(activeHandler) {
         this.activeStatePromise.then(() => {
             activeHandler(this)
         })
@@ -310,10 +404,10 @@ export default class Deposit {
      * Vending Machine contract in exchange for TBTC. Requires that the deposit
      * already be qualified, i.e. in the ACTIVE state.
      *
-     * @return A promise to the amount of TBTC that was minted to the deposit
-     *         owner.
+     * @return {Promise<BN>} A promise to the amount of TBTC that was minted to
+     *         the deposit owner.
      */
-    async mintTBTC()/*: Promise<BN>*/ {
+    async mintTBTC() {
         if (! await this.contract.inActive()) {
             throw new Error(
                 "Can't mint TBTC with a deposit that isn't in ACTIVE state."
@@ -356,14 +450,14 @@ export default class Deposit {
      * mint TBTC off of it, transferring ownership of the deposit to the
      * Vending Machine.
      *
-     * @return A promise to the amount of TBTC that was minted to the deposit
-     *         owner.
+     * @return {Promise<BN>} A promise to the amount of TBTC that was minted to
+     *         the deposit owner.
      *
      * @throws When there is no existing Bitcoin funding transaction with the
      *         appropriate number of confirmations, or if there is an issue
      *         in the Vending Machine's qualification + minting process.
      */
-    async qualifyAndMintTBTC()/*: Promise<BN>*/ {
+    async qualifyAndMintTBTC() {
         const address = await this.bitcoinAddress
         const expectedValue = (await this.getSatoshiLotSize()).toNumber()
         const tx = await BitcoinHelpers.Transaction.find(address, expectedValue)
@@ -425,9 +519,10 @@ export default class Deposit {
      * the tBTC Vending Machine, includes the cost of retrieving it from the
      * Vending Machine.
      *
-     * @return A promise to the amount of TBTC needed to redeem this deposit.
+     * @return {Promise<BN>} A promise to the amount of TBTC needed to redeem
+     *         this deposit.
      */
-    async getRedemptionCost()/*: Promise<BN>*/ {
+    async getRedemptionCost() {
         if (await this.inVendingMachine()) {
             const ownerRedemptionRequirement =
                 await this.contract.getOwnerRedemptionTbtcRequirement(
@@ -452,7 +547,20 @@ export default class Deposit {
         return new Redemption(this, details)
     }
 
-    async requestRedemption(redeemerAddress/*: string /* bitcoin address */)/*: Promise<Redemption>*/ {
+    /**
+     *  
+     * @param {string} redeemerAddress The Bitcoin address where the redeemer
+     *        like to receive the BTC UTXO the deposit holds, less Bitcoin
+     *        transaction fees.
+     * @return {Promise<Redemption>} Returns a promise to a Redemption object,
+     *         which will be fulfilled once the redemption process is in
+     *         progress. Note that the promise can fail in several ways,
+     *         including connectivity, a deposit ineligible for redemption, a
+     *         deposit that is not owned by the requesting party, an invalid
+     *         redeemer address, and a redemption request from a party that has
+     *         insufficient TBTC to redeem.
+     */
+    async requestRedemption(redeemerAddress) {
         const inVendingMachine = await this.inVendingMachine()
         const thisAccount = this.factory.config.web3.eth.defaultAccount
         const owner = await this.getOwner()

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -550,7 +550,7 @@ export default class Deposit {
     /**
      *  
      * @param {string} redeemerAddress The Bitcoin address where the redeemer
-     *        like to receive the BTC UTXO the deposit holds, less Bitcoin
+     *        would like to receive the BTC UTXO the deposit holds, less Bitcoin
      *        transaction fees.
      * @return {Promise<Redemption>} Returns a promise to a Redemption object,
      *         which will be fulfilled once the redemption process is in

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -127,6 +127,8 @@ export default class Redemption {
                 requesterPKH.replace('0x', ''),
                 this.deposit.factory.config.bitcoinNetwork,
             )
+            // FIXME Check that the transaction spends the right UTXO, not just
+            // FIXME that it's the right amount to the right address.
             let transaction = await BitcoinHelpers.Transaction.find(
                 requesterAddress,
                 expectedValue,

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -1,43 +1,53 @@
 import { DepositFactory } from "./Deposit.js";
 
+/** @enum {string} */
 const BitcoinNetwork = {
     TESTNET: "testnet",
     MAINNET: "mainnet"
 }
 
-/*
-export type TBTCConfig = {
-    bitcoinNetwork: BitcoinNetwork,
-    web3: Web3,
-}
-*/
+/**
+ * @typedef {Object} TBTCConfig
+ * @prop {BitcoinNetwork} bitcoinNetwork
+ * @prop {Web3} web3
+ */
 
-const defaultConfig/*: TBTCConfig */ = {
+/** @type {TBTCConfig} */
+const defaultConfig = {
     bitcoinNetwork: BitcoinNetwork.TESTNET,
     web3: global.Web3,
 }
 
-function isMainnet(web3/*: Web3*/) {
+/**
+ * @param {Web3} web3 
+ */
+function isMainnet(web3) {
     return web3.currentProvider['chainId'] == 0x1
 }
-function isTestnet(web3/*: Web3*/) {
+/**
+ * @param {Web3} web3 
+ */
+function isTestnet(web3) {
     return ! isMainnet(web3)
 }
 
-class TBTC {
-    // config/*: TBTCConfig*/;
-    // depositFactory/*: DepositFactory*/;
-
-    static async withConfig(config = defaultConfig/*: TBTCConfig*/, networkMatchCheck = true) {
+export class TBTC {
+    static async withConfig(config = defaultConfig, networkMatchCheck = true) {
         const depositFactory = await DepositFactory.withConfig(config)
 
         return new TBTC(depositFactory, config, networkMatchCheck)
     }
 
-    constructor(depositFactory/*: DepositFactory*/, config/*: TBTCConfig*/ = defaultConfig, networkMatchCheck = true) {
+    /**
+     * 
+     * @param {DepositFactory} depositFactory 
+     * @param {TBTCConfig} config 
+     * @param {boolean} networkMatchCheck 
+     */
+    constructor(depositFactory, config, networkMatchCheck = true) {
         if (networkMatchCheck &&
-            isMainnet(config.web3) && config.bitcoinNetwork == BitcoinNetwork.TESTNET ||
-            isTestnet(config.web3) && config.bitcoinNetwork == BitcoinNetwork.MAINNET) {
+            isMainnet(config.web3) && config.bitcoinNetwork == BitcoinHelpers.Network.TESTNET ||
+            isTestnet(config.web3) && config.bitcoinNetwork == BitcoinHelpers.Network.MAINNET) {
                 throw new Error(
                     `Ethereum network ${config.web3.currentProvider.chainId} ` +
                     `and Bitcoin network ${config.bitcoinNetwork} are not both ` +
@@ -47,7 +57,9 @@ class TBTC {
                 )
         }
 
+        /** @package */
         this.depositFactory = depositFactory
+        /** @package */
         this.config = config
     }
 
@@ -57,7 +69,11 @@ class TBTC {
 }
 
 export default {
-    withConfig: async (config/*: TBTCConfig*/, networkMatchCheck = true) => {
+    /**
+     * @param {TBTCConfig} config
+     * @param {boolean} networkMatchCheck 
+     */
+    withConfig: async (config, networkMatchCheck = true) => {
         return await TBTC.withConfig(config, networkMatchCheck)
     }
 };


### PR DESCRIPTION
> [**Typing Day** (also known as **International Typing Day** or **World Typing Day**) is an annual event that falls on 8 January in Malaysia. It is co-organized by the STC (Speed Typing Contest) Team from JCI (Junior Chamber International) Mines and Team TAC (Typo Auto Corrector) to promote speed, accuracy and efficiency in written communication among the public.](https://en.wikipedia.org/wiki/Typing_Day)

This goes through a large swath of the functionality of the library and
annotates types throughout using JSDoc. Editors like VSCode and
compilers like TypeScript can pull this information, implicitly or
sometimes explicitly through /** import */ declarations, alongside
`@ts-check` annotations, to typecheck code that uses tbtc.js, either in
TypeScript or in regular JS.

-----------

The goal here isn't to be 100% complete, but to get close and hit most of the common code paths.