### PR TITLE
Iron Confederacy: Improve tbtc.js for usage by the tBTC reference dApp

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   "dependencies": {
     "@keep-network/tbtc": "0.6.0-pre1",
     "@truffle/contract": "^4.1.8",
-    "@truffle/hdwallet-provider": "^1.0.30",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
     "bcrypto": "^4.1.0",
     "bufio": "^1.0.6",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0"
   },
   "devDependencies": {
+    "@truffle/hdwallet-provider": "^1.0.30",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "eslint-config-keep": "git+https://github.com/keep-network/eslint-config-keep.git#0.2.0",

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -11,12 +11,14 @@ import { BitcoinSPV } from "./lib/BitcoinSPV.js"
 import { BitcoinTxParser } from "./lib/BitcoinTxParser.js"
 import ElectrumClient from "./lib/ElectrumClient.js"
 
+import BN from "bn.js"
 
 /** @enum {string} */
 const BitcoinNetwork = {
     TESTNET: "testnet",
     MAINNET: "mainnet",
 }
+
 /**
  * Found transaction details.
  * @typedef FoundTransaction
@@ -27,6 +29,8 @@ const BitcoinNetwork = {
 */
 
 const BitcoinHelpers = {
+    satoshisPerBtc: (new BN(10)).pow(new BN(8)),
+
     Network: BitcoinNetwork,
 
     electrumConfig: null,

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -11,6 +11,12 @@ import { BitcoinSPV } from "./lib/BitcoinSPV.js"
 import { BitcoinTxParser } from "./lib/BitcoinTxParser.js"
 import ElectrumClient from "./lib/ElectrumClient.js"
 
+
+/** @enum {string} */
+const BitcoinNetwork = {
+    TESTNET: "testnet",
+    MAINNET: "mainnet",
+}
 /**
  * Found transaction details.
  * @typedef FoundTransaction
@@ -21,6 +27,8 @@ import ElectrumClient from "./lib/ElectrumClient.js"
 */
 
 const BitcoinHelpers = {
+    Network: BitcoinNetwork,
+
     electrumConfig: null,
     /**
      * Updates the config to use for Electrum client connections. Electrum is
@@ -106,7 +114,7 @@ const BitcoinHelpers = {
          * [BIP-173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki).
          * @param {string} publicKeyString Public key as a hexadecimal representation of
          * 64-byte concatenation of x and y coordinates.
-         * @param {Network} network Network for which address has to be calculated.
+         * @param {BitcoinNetwork} network Network for which address has to be calculated.
          * @return {string} A Bitcoin P2WPKH address for given network.
          */
         publicKeyToP2WPKHAddress: function(publicKeyString, network) {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -26,6 +26,34 @@ const FeeRebateTokenContract = TruffleContract(FeeRebateTokenJSON)
 const VendingMachineContract = TruffleContract(VendingMachineJSON)
 const ECDSAKeepContract = TruffleContract(ECDSAKeepJSON)
 
+/** @enum {number} */
+const DepositStates = {
+    // Not initialized.
+    START: 0,
+
+    // Funding flow.
+    AWAITING_SIGNER_SETUP: 1,
+    AWAITING_BTC_FUNDING_PROOF: 2,
+
+    // Failed setup.
+    FRAUD_AWAITING_BTC_FUNDING_PROOF: 3,
+    FAILED_SETUP: 4,
+
+    // Active/qualified, pre- or at-term.
+    ACTIVE: 5,
+
+    // Redemption flow.
+    AWAITING_WITHDRAWAL_SIGNATURE: 6,
+    AWAITING_WITHDRAWAL_PROOF: 7,
+    REDEEMED: 8,
+
+    // Signer liquidation flow.
+    COURTESY_CALL: 9,
+    FRAUD_LIQUIDATION_IN_PROGRESS: 10,
+    LIQUIDATION_IN_PROGRESS: 11,
+    LIQUIDATED: 12
+}
+
 export class DepositFactory {
     // config/*: TBTCConfig*/;
 
@@ -50,6 +78,8 @@ export class DepositFactory {
 
     constructor(config/*: TBTCConfig*/) {
         this.config = config
+
+        this.State = DepositStates
     }
 
     async availableSatoshiLotSizes()/*: Promise<BN[]>*/ {
@@ -248,6 +278,13 @@ export default class Deposit {
      */
     async getBitcoinAddress() {
         return await this.bitcoinAddress
+    }
+
+    /**
+     * @return {DepositStates} The current state of the deposit.
+     */
+    async getCurrentState() {
+        return (await this.contract.getCurrentState()).toNumber()
     }
 
     async getTDT()/*: Promise<TBTCDepositToken>*/ {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -628,7 +628,7 @@ export default class Deposit {
     /**
      * @typedef {Object} AutoSubmitState
      * @prop {Promise<BitcoinTransaction>} fundingTransaction
-     * @prop {Promise<{ transaction: FoundTransaction, requiredConfirmations: Number }>} resolvedConfirmations
+     * @prop {Promise<{ transaction: FoundTransaction, requiredConfirmations: Number }>} fundingConfirmations
      * @prop {Promise<EthereumTransaction>} proofTransaction
      */
     /**
@@ -670,7 +670,7 @@ export default class Deposit {
             return BitcoinHelpers.Transaction.findOrWaitFor(address, expectedValue)
         })
 
-        state.resolvedConfirmations = state.fundingTransaction.then(async (transaction) => {
+        state.fundingConfirmations = state.fundingTransaction.then(async (transaction) => {
             const requiredConfirmations = (await this.factory.constantsContract.getTxProofDifficultyFactor()).toNumber()
 
             console.debug(
@@ -685,7 +685,7 @@ export default class Deposit {
             return { transaction, requiredConfirmations }
         })
 
-        state.proofTransaction = state.resolvedConfirmations.then(async ({ transaction, requiredConfirmations }) => {
+        state.proofTransaction = state.fundingConfirmations.then(async ({ transaction, requiredConfirmations }) => {
             console.debug(
                 `Submitting funding proof to deposit ${this.address} for ` +
                 `Bitcoin transaction ${transaction.transactionID}...`

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -599,6 +599,9 @@ export default class Deposit {
      * a deposit, then transfer the deposit to a service provider who will
      * handle deposit qualification.
      *
+     * Calling this function more than once will return the existing state of
+     * the first auto submission process, rather than restarting the process.
+     *
      * @return {AutoSubmitState} An object with promises to various stages of
      *         the auto-submit lifetime. Each promise can be fulfilled or
      *         rejected, and they are in a sequence where later promises will be

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -483,10 +483,19 @@ export default class Deposit {
         }
     }
 
-    async getCurrentRedemption()/*: Promise<Redemption?>*/ {
+    /**
+     * Checks to see if this deposit is already in the redemption process and,
+     * if it is, returns the details of that redemption. Returns null if there
+     * is no current redemption.
+     */
+    async getCurrentRedemption() {
         const details = await this.getLatestRedemptionDetails()
 
-        return new Redemption(this, details)
+        if (details) {
+            return new Redemption(this, details)
+        } else {
+            return null
+        }
     }
 
     async requestRedemption(redeemerAddress/*: string /* bitcoin address */)/*: Promise<Redemption>*/ {

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -107,15 +107,11 @@ export default class Redemption {
         })
     }
 
-    // autoSubmitting/*: boolean*/
     autoSubmit() {
-        // Only enable auto-submitting once.
-        if (this.autoSubmitting) {
-            return
+        if (this.autoSubmitPromise) {
+            return this.autoSubmitPromise
         }
-        this.autoSubmitting = true
-
-        this.signedTransaction.then(async (signedTransaction) => {
+        this.autoSubmitPromise = this.signedTransaction.then(async (signedTransaction) => {
             console.debug(
                 `Looking for existing signed redemption transaction on Bitcoin ` +
                 `chain for deposit ${this.deposit.address}...`
@@ -157,7 +153,7 @@ export default class Redemption {
                 `Transaction is sufficiently confirmed; submitting redemption ` +
                 `proof to deposit ${this.deposit.address}...`
             )
-            this.proveWithdrawal(transaction.transactionID, requiredConfirmations)
+            return this.proveWithdrawal(transaction.transactionID, requiredConfirmations)
         })
         // TODO bumpFee if needed
     }

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -1,5 +1,6 @@
 import { DepositFactory } from "./Deposit.js";
 import BitcoinHelpers from "./BitcoinHelpers.js";
+import BN from "bn.js"
 /** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork
 
 
@@ -48,6 +49,8 @@ class TBTC {
 
         this.depositFactory = depositFactory
         this.config = config
+
+        this.satoshisPerTbtc = (new BN(10)).pow(new BN(10))
     }
 
     get Deposit()/*: DepositFactory*/ {

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -1,9 +1,7 @@
 import { DepositFactory } from "./Deposit.js";
+import BitcoinHelpers from "./BitcoinHelpers.js";
+/** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork
 
-const BitcoinNetwork = {
-    TESTNET: "testnet",
-    MAINNET: "mainnet"
-}
 
 /*
 export type TBTCConfig = {
@@ -13,7 +11,8 @@ export type TBTCConfig = {
 */
 
 const defaultConfig/*: TBTCConfig */ = {
-    bitcoinNetwork: BitcoinNetwork.TESTNET,
+const defaultConfig = {
+    bitcoinNetwork: BitcoinHelpers.Network.TESTNET,
     web3: global.Web3,
 }
 
@@ -59,5 +58,6 @@ class TBTC {
 export default {
     withConfig: async (config/*: TBTCConfig*/, networkMatchCheck = true) => {
         return await TBTC.withConfig(config, networkMatchCheck)
-    }
+    },
+    BitcoinNetwork: BitcoinHelpers.Network,
 };


### PR DESCRIPTION
> [Poundmaker (1842 – 4 July 1886), born Pîhtokahanapiwiyin, was a Plains Cree chief. He leads the Cree in Civilization VI: Rise and Fall.](https://civilization.fandom.com/wiki/Poundmaker_(Civ6))
> …
> [Poundmaker's unique agenda is called **Iron Confederacy**. He tries to establish as many alliances as possible, and dislikes civilizations that don't establish alliances.](https://civilization.fandom.com/wiki/Poundmaker_(Civ6))

While porting the reference dApp from its haphazard internal library to tbtc.js, several missing hooks and API cleanups became apparent. This PR implements those hooks and cleans up those APIs, including:

- Access to a deposit's current state.
- Access to BTC-satoshi and TBTC-satoshi conversion factors.
- Tweaks in the behavior of `getCurrentRedemption`.
- Exposure to the intermediate steps of auto-submission for both deposit creation and redemption flows.

It's a smashing good time 👊 