### PR TITLE
Tranche Deux: Add helper for converting ABI-coded `bytes` into their underlying bytes

### DIFF
--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -81,8 +81,19 @@ async function getExistingEvent(source, eventName, filter) {
   return events[0]
 }
 
+/**
+ * Converts an Ethereum `bytes` value into the raw bytes it represents.
+ * Drops the 0x prefix, and the length prefix.
+ * @param {string} bytesString An Ethereum-encoded `bytes` string
+ * @return {string} The hexadecimal string.
+ */
+function bytesToRaw(bytesString) {
+  return bytesString.replace("0x", "").slice(2)
+}
+
 export default {
   getEvent,
   getExistingEvent,
-  readEventFromTransaction
+  readEventFromTransaction,
+  bytesToRaw
 }

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -67,11 +67,7 @@ export default class Redemption {
         // https://github.com/summa-tx/bitcoin-spv/blob/2a9d594d9b14080bdbff2a899c16ffbf40d62eef/solidity/contracts/CheckBitcoinSigs.sol#L154
         0,
         outputValue.toNumber(),
-        // Drop the 0x prefix if present, since bcoin doesn't roll
-        // with that. Then drop the length prefix that's necessary
-        // in Ethereum-land, since it's not strictly part of the
-        // output script.
-        details.redeemerOutputScript.replace("0x", "").slice(2)
+        EthereumHelpers.bytesToRaw(details.redeemerOutputScript)
       )
 
       return {
@@ -155,7 +151,7 @@ export default class Redemption {
         // FIXME that it's the right amount to the right address. outpoint
         // FIXME compared against vin is probably the move here.
         let transaction = await BitcoinHelpers.Transaction.findScript(
-          redeemerOutputScript.replace("0x", "").slice(2),
+          EthereumHelpers.bytesToRaw(redeemerOutputScript),
           expectedValue
         )
 


### PR DESCRIPTION
This makes the code easier to read for Bitcoiners, and the like, without having to understand the specifics of the EVM ABI coding.

Follow-up from #10.