### PR TITLE
Touchups

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -389,6 +389,14 @@ export default class Deposit {
   }
 
   /**
+   * Get the signer fee, to be paid at redemption.
+   * @return {Promise<BN>} A promise to the signer fee for this deposit, in TBTC.
+   */
+  async getSignerFee() {
+    return toBN(await this.contract.methods.signerFee().call())
+  }
+
+  /**
    * Returns a promise that resolves to the Bitcoin address for the wallet
    * backing this deposit. May take an extended amount of time if this deposit
    * has just been created.

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -392,7 +392,7 @@ export default class Deposit {
    * Get the signer fee, to be paid at redemption.
    * @return {Promise<BN>} A promise to the signer fee for this deposit, in TBTC.
    */
-  async getSignerFee() {
+  async getSignerFeeTBTC() {
     return toBN(await this.contract.methods.signerFee().call())
   }
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -723,7 +723,7 @@ export default class Deposit {
     } else {
       console.debug(`Approving transfer of ${redemptionCost} to the deposit...`)
       this.factory.tokenContract.methods
-        .approve(this.address, redemptionCost)
+        .approve(this.address, redemptionCost.toString())
         .send()
 
       console.debug(`Initiating redemption from deposit ${this.address}...`)


### PR DESCRIPTION
## Add `getSignerFee` helper to Deposit. 
[This line in tbtc-dapp](https://github.com/keep-network/tbtc-dapp/blob/b3cfbe418cf532a3bd2747ffce1740bc41c82650/src/sagas/deposit.js#L78) fails with the new web3 tbtc.js. The new method call would be deposit.methods.signerFee().call(), although the line above uses a helper - I figure we should use one here too.

## Convert redemptionCost BN to string
I found this while investigating our Discord bug. I didn't test this less-travelled code path of redemption.