### PR TITLE
Version Tether: Continuous packaging and versioning

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  repository_dispatch:
+    types: redeploy
 
 jobs:
   build:
@@ -29,7 +31,7 @@ jobs:
     - run: npm test
       env:
         CI: true
-    - if: github.event_name == 'push'
+    - if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
       name: Bump and publish npm package
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,3 +29,40 @@ jobs:
     - run: npm test
       env:
         CI: true
+    - if: github.event_name == 'push'
+      name: Bump and publish npm package
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        set -x
+        name=$(jq --raw-output .name package.json)
+        version=$(jq --raw-output .version package.json)
+        preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+
+        # Find the latest published package version matching this preid.
+        # Note that in jq, we wrap the result in an array and then flatten;
+        # this is because npm show json contains a single string if there
+        # is only one matching version, or an array if there are multiple,
+        # and we want to look at an array always.
+        latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | sort | .[-1]")
+        latest_version=${latest_version:-$version}
+        if [ -z $latest_version ]; then
+          echo "Latest version calculation failed. Resolved info:"
+          echo "$name@$version ; preid $preid"
+          exit 1
+        fi
+
+        # Update package.json with the latest published package version matching this
+        # preid to prepare for bumping.
+        echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+
+        # Bump without doing any git work. Versioning is a build-time action for us.
+        # Consider including commit id? Would be +<commit id>.
+        npm version prerelease --preid=$preid --no-git-tag-version
+
+        # Fix resolved dependency versions.
+        npm update
+
+        # Publish to npm.
+        echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        npm publish --access=public

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
    hooks:
     - id: lint-js
       name: 'lint js'
-      entry: npm run lint:js
+      entry: /usr/bin/env npm run lint:js
       files: '\.js$'
       language: script
       description: "Checks JS code according to the package's linter configuration"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.10.0-pre",
+  "version": "0.12.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,10 +25,12 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.10.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.10.0-pre.0.tgz",
-      "integrity": "sha512-l3UeF9r3W3ZhY/Wp6eYYw/TfxqvNEc9hgShM+0S3NlPGxmSg4TaFM5PTyqLj2/e6jtq7iRHhQQgN41Zk5TSiAA==",
+      "version": "0.12.0-pre.4",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-pre.4.tgz",
+      "integrity": "sha512-UF5RsCB4HunM9B4YJ48PQVwqQHcuiogxXSU7hCOxH+xGhNhi01IJQohCvj+cWTojbTCd4eOcWxSSx5O5ixsMfg==",
       "requires": {
+        "@openzeppelin/contracts-ethereum-package": "^2.4.0",
+        "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"
       },
       "dependencies": {
@@ -40,13 +42,15 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.10.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.10.0-pre.0.tgz",
-      "integrity": "sha512-hyIVZjdV3ZCerB5XBQlL/miy6tzA/N/+WtloJKu9GO4wTi52swdOMbmLI8ZlGZ6+lqXG3V33p7W2bun9TVontw==",
+      "version": "0.12.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.12.0-pre.2.tgz",
+      "integrity": "sha512-Cz7y1GLMv27p/W8ksK8hf59SWzd65tQuoCnCCNJ+eyWgZIS6q6QlC6ikudUWUg6TK+BFfsSbkLTyHU6DUchRag==",
       "requires": {
-        "@keep-network/keep-core": "0.10.0-pre.0",
+        "@keep-network/keep-core": ">0.12.0-pre <0.12.0-rc",
         "@keep-network/sortition-pools": "0.1.1",
-        "openzeppelin-solidity": "2.3.0"
+        "@openzeppelin/upgrades": "^2.7.2",
+        "openzeppelin-solidity": "2.3.0",
+        "solidity-bytes-utils": "0.0.7"
       }
     },
     "@keep-network/sortition-pools": {
@@ -59,13 +63,14 @@
       }
     },
     "@keep-network/tbtc": {
-      "version": "0.10.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-0.10.0-pre.0.tgz",
-      "integrity": "sha512-SPyXV3I3HWrVwp/dJAnDIyp/1nde+RX4A7YG+ZDyLC94XrJKXUD6Pj9DEEBr6RJqASQeTVhV+6V+3sxdkCZeEA==",
+      "version": "0.12.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-0.12.0-pre.0.tgz",
+      "integrity": "sha512-2iwUwigxdmeHjLktph2rKiP7N/zNSlwgu6CJkBIByxLik51Qzi/alcAo55hGOJmR2rvAVoeJr4ij7k15OSpcog==",
       "requires": {
-        "@keep-network/keep-ecdsa": "0.10.0-pre.0",
+        "@keep-network/keep-ecdsa": ">0.12.0-pre <0.12.0-rc",
         "@summa-tx/bitcoin-spv-sol": "^2.2.0",
         "@summa-tx/relay-sol": "^1.1.0",
+        "@truffle/hdwallet-provider": "^1.0.26",
         "bn-chai": "^1.0.1",
         "bn.js": "^4.11.8",
         "create-hash": "^1.2.0",
@@ -77,6 +82,526 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
       "integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+    },
+    "@openzeppelin/contracts-ethereum-package": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
+      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
+    },
+    "@openzeppelin/upgrades": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
+      "integrity": "sha512-LzjTQPeljPsgHDPdZyH9cMCbIHZILgd2cpNcYEkdsC2IylBYRHShlbEDXJV9snnqg9JWfzPiKIqyj3XVliwtqQ==",
+      "requires": {
+        "@types/cbor": "^2.0.0",
+        "axios": "^0.18.0",
+        "bignumber.js": "^7.2.0",
+        "cbor": "^4.1.5",
+        "chalk": "^2.4.1",
+        "ethers": "^4.0.20",
+        "glob": "^7.1.3",
+        "lodash": "^4.17.15",
+        "semver": "^5.5.1",
+        "spinnies": "^0.4.2",
+        "truffle-flattener": "^1.4.0",
+        "web3": "1.2.2",
+        "web3-eth": "1.2.2",
+        "web3-eth-contract": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethers": {
+          "version": "4.0.46",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.46.tgz",
+          "integrity": "sha512-/dPMzzpInhtiip4hKFvsDiJKeRk64IhyA+Po7CtNXneQFSOCYXg8eBFt+jXbxUQyApgWnWOtYxWdfn9+CvvxDA==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
+          "integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.2",
+            "web3-core": "1.2.2",
+            "web3-eth": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-shh": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
+          "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.18",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+              "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
+          "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-requestmanager": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
+          "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
+          "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
+          "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
+          "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-providers-http": "1.2.2",
+            "web3-providers-ipc": "1.2.2",
+            "web3-providers-ws": "1.2.2"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
+          "integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
+          "integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-eth-accounts": "1.2.2",
+            "web3-eth-contract": "1.2.2",
+            "web3-eth-ens": "1.2.2",
+            "web3-eth-iban": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.2.tgz",
+          "integrity": "sha512-Yn/ZMgoOLxhTVxIYtPJ0eS6pnAnkTAaJgUJh1JhZS4ekzgswMfEYXOwpMaD5eiqPJLpuxmZFnXnBZlnQ1JMXsw==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.18",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+              "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
+          "integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-shim": "github:web3-js/scrypt-shim",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
+          "integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
+          "integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-eth-contract": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
+          "integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
+          "integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
+          "integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
+          "integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
+          "requires": {
+            "web3-core-helpers": "1.2.2",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
+          "integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
+          "integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
+          "integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-net": "1.2.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
+      }
+    },
+    "@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+      "requires": {
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "requires": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -461,7 +986,6 @@
       "version": "1.0.30",
       "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.30.tgz",
       "integrity": "sha512-i2xNocQ8Pw8g24Q2hGRy5VLzQsAA10EC63msBEP+ldc9xGLzAV86qOboEqjf/h1PZm0LtXzs8lRfW+iF5Xdc2A==",
-      "dev": true,
       "requires": {
         "any-promise": "^1.3.0",
         "bindings": "^1.5.0",
@@ -478,7 +1002,6 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
           "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-          "dev": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
           }
@@ -487,7 +1010,6 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
           "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-          "dev": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -497,14 +1019,12 @@
         "ethereum-common": {
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
-          "dev": true
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
         },
         "ethereumjs-tx": {
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
           "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-          "dev": true,
           "requires": {
             "ethereum-common": "^0.0.18",
             "ethereumjs-util": "^5.0.0"
@@ -514,7 +1034,6 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
               "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-              "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -531,7 +1050,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -542,20 +1060,17 @@
         "semver": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
-          "dev": true
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
         },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "web3": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
           "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
-          "dev": true,
           "requires": {
             "web3-bzz": "1.2.1",
             "web3-core": "1.2.1",
@@ -570,7 +1085,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
           "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
-          "dev": true,
           "requires": {
             "got": "9.6.0",
             "swarm-js": "0.1.39",
@@ -581,7 +1095,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
           "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
-          "dev": true,
           "requires": {
             "web3-core-helpers": "1.2.1",
             "web3-core-method": "1.2.1",
@@ -593,7 +1106,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
           "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
-          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.1",
@@ -604,7 +1116,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
           "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
-          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
@@ -617,7 +1128,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
           "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
-          "dev": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -627,7 +1137,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
           "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
-          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
@@ -640,7 +1149,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
           "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
-          "dev": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -651,7 +1159,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
           "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
-          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core": "1.2.1",
@@ -672,7 +1179,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
           "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
-          "dev": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -683,7 +1189,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
           "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
-          "dev": true,
           "requires": {
             "any-promise": "1.3.0",
             "crypto-browserify": "3.12.0",
@@ -702,7 +1207,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
           "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
-          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core": "1.2.1",
@@ -718,7 +1222,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
           "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
-          "dev": true,
           "requires": {
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
@@ -734,7 +1237,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
           "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.1"
@@ -744,7 +1246,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
           "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
-          "dev": true,
           "requires": {
             "web3-core": "1.2.1",
             "web3-core-helpers": "1.2.1",
@@ -757,7 +1258,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
           "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
-          "dev": true,
           "requires": {
             "web3-core": "1.2.1",
             "web3-core-method": "1.2.1",
@@ -767,7 +1267,6 @@
         "web3-provider-engine": {
           "version": "git+https://github.com/trufflesuite/provider-engine.git#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a",
           "from": "git+https://github.com/trufflesuite/provider-engine.git#web3-one",
-          "dev": true,
           "requires": {
             "async": "^2.5.0",
             "backoff": "^2.5.0",
@@ -795,7 +1294,6 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
               "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-              "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -812,7 +1310,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
           "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
-          "dev": true,
           "requires": {
             "web3-core-helpers": "1.2.1",
             "xhr2-cookies": "1.1.0"
@@ -822,7 +1319,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
           "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
-          "dev": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -833,7 +1329,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
           "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
-          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
@@ -844,7 +1339,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
           "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
-          "dev": true,
           "requires": {
             "web3-core": "1.2.1",
             "web3-core-method": "1.2.1",
@@ -856,7 +1350,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
           "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -870,7 +1363,6 @@
         "websocket": {
           "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
           "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-          "dev": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -882,8 +1374,7 @@
             "nan": {
               "version": "2.14.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
+              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
             }
           }
         },
@@ -891,7 +1382,6 @@
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -1307,6 +1797,14 @@
         "@types/node": "*"
       }
     },
+    "@types/cbor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
+      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -1395,7 +1893,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1490,11 +1987,19 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -1504,14 +2009,12 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1523,14 +2026,12 @@
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -1538,7 +2039,6 @@
       "version": "6.26.3",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-generator": "^6.26.0",
@@ -1565,7 +2065,6 @@
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
       "requires": {
         "babel-messages": "^6.23.0",
         "babel-runtime": "^6.26.0",
@@ -1580,8 +2079,7 @@
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         }
       }
     },
@@ -1589,7 +2087,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1600,7 +2097,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1612,7 +2108,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -1624,7 +2119,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-traverse": "^6.24.1",
@@ -1635,7 +2129,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1648,7 +2141,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -1658,7 +2150,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -1668,7 +2159,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -1678,7 +2168,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-types": "^6.26.0",
@@ -1689,7 +2178,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1702,7 +2190,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "^6.24.1",
         "babel-messages": "^6.23.0",
@@ -1716,7 +2203,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -1726,7 +2212,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1735,7 +2220,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1743,26 +2227,22 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
         "babel-plugin-syntax-async-functions": "^6.8.0",
@@ -1773,7 +2253,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1782,7 +2261,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1791,7 +2269,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-template": "^6.26.0",
@@ -1804,7 +2281,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
       "requires": {
         "babel-helper-define-map": "^6.24.1",
         "babel-helper-function-name": "^6.24.1",
@@ -1821,7 +2297,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -1831,7 +2306,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1840,7 +2314,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -1850,7 +2323,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1859,7 +2331,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1870,7 +2341,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1879,7 +2349,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1890,7 +2359,6 @@
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -1902,7 +2370,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1913,7 +2380,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1924,7 +2390,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "^6.24.1",
         "babel-runtime": "^6.22.0"
@@ -1934,7 +2399,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "^6.24.1",
         "babel-helper-get-function-arity": "^6.24.1",
@@ -1948,7 +2412,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -1958,7 +2421,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1967,7 +2429,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -1978,7 +2439,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1987,7 +2447,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1996,7 +2455,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -2007,7 +2465,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -2018,7 +2475,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
       "requires": {
         "regenerator-transform": "^0.10.0"
       }
@@ -2027,7 +2483,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -2037,7 +2492,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -2075,7 +2529,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
       "requires": {
         "babel-core": "^6.26.0",
         "babel-runtime": "^6.26.0",
@@ -2090,7 +2543,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -2100,7 +2552,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-traverse": "^6.26.0",
@@ -2113,7 +2564,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-messages": "^6.23.0",
@@ -2129,8 +2579,7 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         }
       }
     },
@@ -2138,7 +2587,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -2150,7 +2598,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-      "dev": true,
       "requires": {
         "babel-core": "^6.0.14",
         "object-assign": "^4.0.0"
@@ -2159,14 +2606,12 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "backoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
       "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-      "dev": true,
       "requires": {
         "precond": "0.2"
       }
@@ -2333,8 +2778,9 @@
       }
     },
     "bignumber.js": {
-      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "bindings": {
       "version": "1.3.1",
@@ -2524,7 +2970,6 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30000844",
         "electron-to-chromium": "^1.3.47"
@@ -2661,8 +3106,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-map": {
       "version": "0.0.7",
@@ -2769,13 +3213,35 @@
     "caniuse-lite": {
       "version": "1.0.30001025",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-      "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
-      "dev": true
+      "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ=="
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cbor": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
+      "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "commander": "^3.0.0",
+        "json-text-sequence": "^0.1",
+        "nofilter": "^1.0.3"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        },
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        }
+      }
     },
     "chai": {
       "version": "4.2.0",
@@ -2795,7 +3261,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2840,7 +3305,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -2934,7 +3398,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2942,8 +3405,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2975,7 +3437,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3007,7 +3468,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       },
@@ -3015,8 +3475,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -3038,8 +3497,7 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3093,7 +3551,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
       "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
-      "dev": true,
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
@@ -3102,14 +3559,12 @@
         "node-fetch": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
-          "dev": true
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         },
         "whatwg-fetch": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-          "dev": true
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
     },
@@ -3332,6 +3787,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3355,7 +3815,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -3435,8 +3894,7 @@
     "electron-to-chromium": {
       "version": "1.3.345",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-      "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
-      "dev": true
+      "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg=="
     },
     "electrum-client-js": {
       "version": "git+https://github.com/keep-network/electrum-client-js.git#6bdc216da4228460b6e28706220c70a873f9084d",
@@ -3567,8 +4025,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "6.8.0",
@@ -3769,8 +4226,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -3781,7 +4237,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
       "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
-      "dev": true,
       "requires": {
         "eth-query": "^2.1.0",
         "ethereumjs-tx": "^1.3.3",
@@ -3795,14 +4250,12 @@
         "ethereum-common": {
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
-          "dev": true
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
         },
         "ethereumjs-tx": {
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
           "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-          "dev": true,
           "requires": {
             "ethereum-common": "^0.0.18",
             "ethereumjs-util": "^5.0.0"
@@ -3812,7 +4265,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -3827,7 +4279,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -3857,7 +4308,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
       "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
-      "dev": true,
       "requires": {
         "cross-fetch": "^2.1.1",
         "eth-json-rpc-middleware": "^1.5.0",
@@ -3869,7 +4319,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
       "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
-      "dev": true,
       "requires": {
         "async": "^2.5.0",
         "eth-query": "^2.1.2",
@@ -3889,14 +4338,12 @@
         "ethereum-common": {
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
-          "dev": true
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
         },
         "ethereumjs-tx": {
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
           "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-          "dev": true,
           "requires": {
             "ethereum-common": "^0.0.18",
             "ethereumjs-util": "^5.0.0"
@@ -3906,7 +4353,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -3921,7 +4367,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -3948,7 +4393,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
       "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
-      "dev": true,
       "requires": {
         "json-rpc-random-id": "^1.0.0",
         "xtend": "^4.0.1"
@@ -3958,7 +4402,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-      "dev": true,
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
@@ -3968,7 +4411,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -3983,7 +4425,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -3997,7 +4438,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz",
       "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
-      "dev": true,
       "requires": {
         "async": "^2.1.2",
         "clone": "^2.0.0",
@@ -4014,14 +4454,12 @@
         "ethereum-common": {
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
-          "dev": true
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
         },
         "ethereumjs-tx": {
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
           "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-          "dev": true,
           "requires": {
             "ethereum-common": "^0.0.18",
             "ethereumjs-util": "^5.0.0"
@@ -4031,7 +4469,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -4046,13 +4483,27 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
             "nan": "^2.2.1",
             "safe-buffer": "^5.1.0"
           }
+        }
+      }
+    },
+    "ethereum-bloom-filters": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
+      "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+      "requires": {
+        "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         }
       }
     },
@@ -4084,13 +4535,11 @@
     "ethereum-protocol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
-      "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg==",
-      "dev": true
+      "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg=="
     },
     "ethereumjs-abi": {
       "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -4390,8 +4839,7 @@
     "events": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
-      "dev": true
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -4524,7 +4972,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
       "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
-      "dev": true,
       "requires": {
         "node-fetch": "~1.7.1"
       }
@@ -4605,6 +5052,24 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -4828,7 +5293,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -4836,8 +5300,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -4905,7 +5368,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
@@ -5139,7 +5601,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -5167,8 +5628,7 @@
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-      "dev": true
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.1.5",
@@ -5189,14 +5649,12 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
-      "dev": true
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -5317,15 +5775,14 @@
       }
     },
     "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -5345,8 +5802,7 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -5357,7 +5813,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
       "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
-      "dev": true,
       "requires": {
         "async": "^2.0.1",
         "babel-preset-env": "^1.7.0",
@@ -5371,7 +5826,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
       "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1"
       }
@@ -5379,8 +5833,7 @@
     "json-rpc-random-id": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg=",
-      "dev": true
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -5396,7 +5849,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
       }
@@ -5412,11 +5864,18 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -5429,8 +5888,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5666,7 +6124,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -5831,8 +6288,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -6070,6 +6526,11 @@
         "is-stream": "^1.0.1"
       }
     },
+    "nofilter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
+      "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6181,7 +6642,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -6208,8 +6668,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
@@ -6314,8 +6773,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -6397,8 +6855,7 @@
     "precond": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
-      "dev": true
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6429,8 +6886,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.5.2",
@@ -6452,7 +6908,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
       "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-      "dev": true,
       "requires": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
@@ -6610,20 +7065,17 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
         "babel-types": "^6.19.0",
@@ -6649,7 +7101,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
       "requires": {
         "regenerate": "^1.2.1",
         "regjsgen": "^0.2.0",
@@ -6659,14 +7110,12 @@
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       }
@@ -6675,7 +7124,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -6756,7 +7204,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -6827,7 +7274,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
       "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
-      "dev": true,
       "requires": {
         "events": "^3.0.0"
       }
@@ -6850,6 +7296,21 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
       "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+    },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "from": "github:web3-js/scrypt-shim",
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
     },
     "scrypt.js": {
       "version": "0.3.0",
@@ -6966,8 +7427,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -7006,8 +7466,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
       "version": "1.0.0",
@@ -7027,8 +7486,7 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -7050,9 +7508,9 @@
       }
     },
     "solc": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.16.tgz",
-      "integrity": "sha512-weEtRtisJyf+8UjELs7S4ST1KK7UIq6SRB7tpprfJBL9b5mTrZAT7m4gJKi2h6MiBpuSWfnraK8BnkyWzuTMRA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.17.tgz",
+      "integrity": "sha512-qpX+PGaU0Q3c6lh2vDzMoIbhv6bIrecI4bYsx+xUs01xsGFnY6Nr0L8y/QMyutTnrHN6Lb/Yl672ZVRqxka96w==",
       "requires": {
         "command-exists": "^1.2.8",
         "commander": "3.0.2",
@@ -7081,6 +7539,11 @@
             "rimraf": "^2.2.8"
           }
         },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -7104,17 +7567,20 @@
         "truffle-hdwallet-provider": "0.0.3"
       }
     },
+    "solidity-parser-antlr": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
+      "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg=="
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -7146,6 +7612,31 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+    },
+    "spinnies": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.4.3.tgz",
+      "integrity": "sha512-TTA2vWXrXJpfThWAl2t2hchBnCMI1JM5Wmb2uyI7Zkefdw/xO98LDy6/SBYwQPiYXL3swx3Eb44ZxgoS8X5wpA==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -7274,7 +7765,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -7465,7 +7955,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -7492,8 +7981,7 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "to-readable-stream": {
       "version": "1.0.0",
@@ -7524,8 +8012,59 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "truffle-flattener": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.2.tgz",
+      "integrity": "sha512-7qUIzaW8a4vI4nui14wsytht2oaqvqnZ1Iet2wRq2T0bCJ0wb6HByMKQhZKpU46R+n5BMTY4K5n+0ITyeNlmuQ==",
+      "requires": {
+        "@resolver-engine/imports-fs": "^0.2.2",
+        "find-up": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "solidity-parser-antlr": "^0.4.11",
+        "tsort": "0.0.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
+      }
     },
     "truffle-hdwallet-provider": {
       "version": "0.0.3",
@@ -7538,6 +8077,10 @@
         "web3-provider-engine": "^8.4.0"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+        },
         "utf8": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
@@ -7562,6 +8105,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
+    },
+    "tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -7614,8 +8162,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.10.0-pre",
+  "version": "0.12.0-pre",
   "type": "module",
   "description": "tbtc.js provides JS bindings to the tBTC system that establishes a TBTC ERC20 token supply-pegged to BTC.",
   "repository": {
@@ -23,7 +23,7 @@
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
   "license": "MIT",
   "dependencies": {
-    "@keep-network/tbtc": ">0.10.0-pre <0.10.0-rc",
+    "@keep-network/tbtc": ">0.12.0-pre <0.12.0-rc",
     "@truffle/contract": "^4.1.8",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
     "bcrypto": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "homepage": "https://github.com/keep-network/tbtc.js",
   "main": "index.js",
   "bin": "./bin/tbtc.js",
+  "files": [
+    "bin/",
+    "src/",
+    "index.js"
+  ],
   "scripts": {
     "test": "mocha --timeout 10000",
     "lint": "npm run lint:js",

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -15,7 +15,7 @@ import DepositFactoryJSON from "@keep-network/tbtc/artifacts/DepositFactory.json
 import TBTCTokenJSON from "@keep-network/tbtc/artifacts/TBTCToken.json"
 import FeeRebateTokenJSON from "@keep-network/tbtc/artifacts/FeeRebateToken.json"
 import VendingMachineJSON from "@keep-network/tbtc/artifacts/VendingMachine.json"
-import BondedECDSAKeepJSON from "@keep-network/tbtc/artifacts/BondedECDSAKeep.json"
+import IBondedECDSAKeepJSON from "@keep-network/tbtc/artifacts/IBondedECDSAKeep.json"
 
 import web3Utils from "web3-utils"
 const { toBN } = web3Utils
@@ -305,7 +305,7 @@ export default class Deposit {
     const contract = new web3.eth.Contract(DepositJSON.abi, depositAddress)
     contract.options.from = web3.eth.defaultAccount
     const keepContract = new web3.eth.Contract(
-      BondedECDSAKeepJSON.abi,
+      IBondedECDSAKeepJSON.abi,
       keepAddress
     )
     keepContract.options.from = web3.eth.defaultAccount
@@ -338,7 +338,7 @@ export default class Deposit {
     const keepAddress = createdEvent.returnValues._keepAddress
     console.debug(`Found keep address ${keepAddress}.`)
     const keepContract = new web3.eth.Contract(
-      BondedECDSAKeepJSON.abi,
+      IBondedECDSAKeepJSON.abi,
       keepAddress
     )
     keepContract.options.from = web3.eth.defaultAccount


### PR DESCRIPTION
This PR picks up the work in keep-core, keep-ecdsa, and tbtc to publish
new npm packages on contract migration. It adds the same functionality
to tbtc.js, and additionally updates the version string referencing tbtc to
properly integrate with tbtc's versioning.

The major changes are:
- `package.json` is set to `<version>-pre`, with no numeric suffix.
- A new workflow step, `Bump and publish npm package`, runs on master
  merge. This step updates the package version to `-pre.<number>`, where
  `<number>` represents a new, unpublished version.
- The package is published to the main npm repository.

In the process, references to keep-ecdsa contracts are also removed so that
tbtc.js can stay only directly dependent on tbtc.