### PR TITLE
Package Versioning: Sorty pants

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -46,7 +46,7 @@ jobs:
         # this is because npm show json contains a single string if there
         # is only one matching version, or an array if there are multiple,
         # and we want to look at an array always.
-        latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | sort | .[-1]")
+        latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
         latest_version=${latest_version:-$version}
         if [ -z $latest_version ]; then
           echo "Latest version calculation failed. Resolved info:"


### PR DESCRIPTION
Using sort sorts lexicographically which runs us into issues when we
increment pre.x to 10.  Rather than lean into sort -n we had a look at
whether or not the result of jq flatten would return a numerically
ordered list.  It looks like it does, so we stripped the sort.

-----

```
sthompson22 ~ $ npm show -json '@keep-network/tbtc.js@^0.12.0-pre' version | jq --raw-output '[.] | flatten ' 
[
  "0.12.0-pre.0",
  "0.12.0-pre.1",
  "0.12.0-pre.2",
  "0.12.0-pre.3",
  "0.12.0-pre.4",
  "0.12.0-pre.5",
  "0.12.0-pre.6",
  "0.12.0-pre.7",
  "0.12.0-pre.8",
  "0.12.0-pre.9",
  "0.12.0-pre.10"
]
```
```
sthompson22 ~ $ npm show -json '@keep-network/tbtc.js@^0.12.0-pre' version | jq --raw-output '[.] | flatten | .[-1] '  
0.12.0-pre.10
```