### PR TITLE
Fix sendParams for EthereumHelpers.sendSafely

### DIFF
--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -116,8 +116,8 @@ async function sendSafely(boundContractMethod, sendParams, forceSend) {
     const gasEstimate = await boundContractMethod.estimateGas({ ...sendParams })
 
     return boundContractMethod.send({
-      gas: gasEstimate,
-      ...sendParams
+      ...sendParams,
+      gas: gasEstimate
     })
   } catch (exception) {
     // If we're not forcibly sending, try to resolve the true error by using

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -112,7 +112,8 @@ function bytesToRaw(bytesString) {
  */
 async function sendSafely(boundContractMethod, sendParams, forceSend) {
   try {
-    const gasEstimate = await boundContractMethod.estimateGas(sendParams)
+    // Clone `sendParams` so we aren't exposed to providers that modify `sendParams`.
+    const gasEstimate = await boundContractMethod.estimateGas({ ...sendParams })
 
     return boundContractMethod.send({
       gas: gasEstimate,


### PR DESCRIPTION
Extracting this out from the approveAndCall PR #21. 

Fixes: #26