### PR TITLE
Bumping up version to 0.15.0-pre.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.15.0-pre",
+  "version": "0.15.0-pre.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.15.0-pre",
+  "version": "0.15.0-pre.1",
   "type": "module",
   "description": "tbtc.js provides JS bindings to the tBTC system that establishes a TBTC ERC20 token supply-pegged to BTC.",
   "repository": {


### PR DESCRIPTION
Bumping up the version to be able to publish it in NPM registry. This is a short-term solution letting us move forward with local setup scripts implementation before we figure out how to set versions properly post-mainnet.

Another option I was considering was to update the version to `1.1.0-pre` but this would be problematic for the following reasons:
- we don't have `1.1.0-pre` for `tbtc -> keep-ecdsa -> keep-core` yet
- we can't refer to `1.0.0` versions from here because we'd get mainnet contract addresses for testnet.