### PR TITLE
Support the btcd "simnet"

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -18,7 +18,8 @@ import BN from "bn.js"
 /** @enum {string} */
 const BitcoinNetwork = {
   TESTNET: "testnet",
-  MAINNET: "mainnet"
+  MAINNET: "mainnet",
+  SIMNET: "simnet"
 }
 
 /**

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -52,6 +52,8 @@ export class TBTC {
       networkMatchCheck &&
       ((isMainnet(config.web3) &&
         config.bitcoinNetwork == BitcoinHelpers.Network.TESTNET) ||
+        (isMainnet(config.web3) &&
+          config.bitcoinNetwork == BitcoinHelpers.Network.SIMNET) ||
         (isTestnet(config.web3) &&
           config.bitcoinNetwork == BitcoinHelpers.Network.MAINNET))
     ) {

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -1,6 +1,7 @@
 import { DepositFactory } from "./Deposit.js"
 import BitcoinHelpers from "./BitcoinHelpers.js"
 import BN from "bn.js"
+import bcoin from "bcoin"
 /** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork
 
 
@@ -69,6 +70,9 @@ export class TBTC {
     this.config = config
 
     this.satoshisPerTbtc = new BN(10).pow(new BN(10))
+    // Set default bcoin network.
+    // This affects how addresses are encoded and displayed.
+    bcoin.set(config.bitcoinNetwork)
   }
 
   get Deposit() /* : DepositFactory*/ {

--- a/src/lib/Address.js
+++ b/src/lib/Address.js
@@ -5,7 +5,7 @@ const Script = require("bcoin/lib/script").Script
 /**
  * Network type enumeration.
  */
-const Network = Object.freeze({ mainnet: 1, testnet: 2 })
+const Network = Object.freeze({ mainnet: 1, testnet: 2, simnet: 4 })
 
 /**
  * Converts public key to bitcoin Witness Public Key Hash Address according to
@@ -55,6 +55,8 @@ function networkToBCOINvalue(network) {
       return "main"
     case Network.testnet:
       return "testnet"
+    case Network.simnet:
+      return "simnet"
     default:
       throw new Error(
         `unsupported network [${networkType}], use one of: [${Object.keys(


### PR DESCRIPTION
simnet is the equivalent of a regtest network in bitcoind. This adds changes such that we encode/display addresses that can be used with btcd's simnet mode.

