### PR TITLE
Move web3-utils to regular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22807,6 +22807,33 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "web3-utils": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+      "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "eth-lib": "0.2.7",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "underscore": "1.9.1",
+        "utf8": "3.0.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        }
+      }
+    },
     "websocket": {
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
     "bcrypto": "^4.1.0",
     "bufio": "^1.0.6",
-    "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0"
+    "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
+    "web3-utils": "^1.2.8"
   },
   "peerDependencies": {
     "web3": "^1.2.0",
-    "web3-provider-engine": "^15.0.7",
-    "web3-utils": "^1.2.8"
+    "web3-provider-engine": "^15.0.7"
   },
   "devDependencies": {
     "@0x/subproviders": "^6.0.8",


### PR DESCRIPTION
Package web3-utils should be a regular not a peer dependency because it's used directly by Deposit.js and Redemption.js