### PR TITLE
Expose redemption autosubmit state

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -332,24 +332,22 @@ const BitcoinHelpers = {
       })
     },
     /**
-     * Watches the Bitcoin chain until the given `transaction` has the given
+     * Watches the Bitcoin chain until the given `transactionID` has the given
      * number of `requiredConfirmations`.
      *
-     * @param {FoundTransaction} transaction Transaction object from Electrum.
+     * @param {string} transactionID A hex Bitcoin transaction id hash.
      * @param {number} requiredConfirmations The number of required
      *        confirmations to wait before returning.
      *
      * @return {Promise<number>} A promise to the final number of confirmations
      *         observed that was at least equal to the required confirmations.
      */
-    waitForConfirmations: async function(transaction, requiredConfirmations) {
-      const id = transaction.transactionID
-
+    waitForConfirmations: async function(transactionID, requiredConfirmations) {
       return BitcoinHelpers.withElectrumClient(async electrumClient => {
         const checkConfirmations = async function() {
           return await BitcoinHelpers.Transaction.checkForConfirmationsWithClient(
             electrumClient,
-            id,
+            transactionID,
             requiredConfirmations
           )
         }

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -833,8 +833,9 @@ export default class Deposit {
           `Waiting for ${requiredConfirmations} confirmations for ` +
             `Bitcoin transaction ${transaction.transactionID}...`
         )
+
         await BitcoinHelpers.Transaction.waitForConfirmations(
-          transaction,
+          transaction.transactionID,
           requiredConfirmations
         )
 

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -184,40 +184,38 @@ export default class Redemption {
             signedTransaction
           )
         }
-
-        return transaction
+        return transaction.transactionID
       }
     )
 
-    state.confirmations = state.broadcastTransactionID.then(async transaction => {
-      const requiredConfirmations = parseInt(
-        await this.deposit.factory.constantsContract.methods
-          .getTxProofDifficultyFactor()
-          .call()
-      )
+    state.confirmations = state.broadcastTransactionID.then(
+      async transactionID => {
+        const requiredConfirmations = parseInt(
+          await this.deposit.factory.constantsContract.methods
+            .getTxProofDifficultyFactor()
+            .call()
+        )
 
-      console.debug(
-        `Waiting for ${requiredConfirmations} confirmations for ` +
-          `Bitcoin transaction ${transaction.transactionID}...`
-      )
-      await BitcoinHelpers.Transaction.waitForConfirmations(
-        transaction,
-        requiredConfirmations
-      )
+        console.debug(
+          `Waiting for ${requiredConfirmations} confirmations for ` +
+            `Bitcoin transaction ${transactionID}...`
+        )
+        await BitcoinHelpers.Transaction.waitForConfirmations(
+          transactionID,
+          requiredConfirmations
+        )
 
-      return { transaction, requiredConfirmations }
-    })
+        return { transactionID, requiredConfirmations }
+      }
+    )
 
     state.proofTransaction = state.confirmations.then(
-      async ({ transaction, requiredConfirmations }) => {
+      async ({ transactionID, requiredConfirmations }) => {
         console.debug(
           `Transaction is sufficiently confirmed; submitting redemption ` +
             `proof to deposit ${this.deposit.address}...`
         )
-        return this.proveWithdrawal(
-          transaction.transactionID,
-          requiredConfirmations
-        )
+        return this.proveWithdrawal(transactionID, requiredConfirmations)
       }
     )
     // TODO bumpFee if needed

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -157,7 +157,7 @@ export default class Redemption {
 
     const state = (this.autoSubmittingState = {})
 
-    state.signedTransaction = this.signedTransaction.then(
+    state.broadcastTransactionID = this.signedTransaction.then(
       async signedTransaction => {
         console.debug(
           `Looking for existing signed redemption transaction on Bitcoin ` +
@@ -189,7 +189,7 @@ export default class Redemption {
       }
     )
 
-    state.confirmations = state.signedTransaction.then(async transaction => {
+    state.confirmations = state.broadcastTransactionID.then(async transaction => {
       const requiredConfirmations = parseInt(
         await this.deposit.factory.constantsContract.methods
           .getTxProofDifficultyFactor()


### PR DESCRIPTION
Redemption autoSubmit now returns an object with promises to various stages of the auto-submit process instead of a single promise. This now mirrors the format of the Deposit autoSubmit method.