### PR TITLE
Fix redemption flow

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -677,8 +677,8 @@ export default class Deposit {
     const transactionFee = await BitcoinHelpers.Transaction.estimateFee(
       this.factory.constantsContract
     )
-    const utxoSize = await this.contract.methods.utxoSize().call()
-    const outputValue = toBN(utxoSize).sub(toBN(transactionFee))
+    const utxoValue = await this.contract.methods.utxoValue().call()
+    const outputValue = toBN(utxoValue).sub(toBN(transactionFee))
     const outputValueBytes = outputValue.toArrayLike(Buffer, "le", 8)
 
     let transaction
@@ -993,7 +993,7 @@ export default class Deposit {
     redemptionRequestedEventArgs
   ) /* : RedemptionDetails*/ {
     const {
-      _utxoSize,
+      _utxoValue,
       _redeemerOutputScript,
       _requestedFee,
       _outpoint,
@@ -1001,7 +1001,7 @@ export default class Deposit {
     } = redemptionRequestedEventArgs
 
     return {
-      utxoSize: toBN(_utxoSize),
+      utxoValue: toBN(_utxoValue),
       redeemerOutputScript: _redeemerOutputScript,
       requestedFee: toBN(_requestedFee),
       outpoint: _outpoint,

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -701,8 +701,7 @@ export default class Deposit {
         this.factory.vendingMachineContract.methods.tbtcToBtc(
           this.address,
           outputValueBytes,
-          redeemerOutputScript,
-          thisAccount
+          redeemerOutputScript
         )
       )
     } else {

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -10,7 +10,7 @@ const { toBN } = web3Utils
 /**
  * Details of a given redemption at a given point in time.
  * @typedef {Object} RedemptionDetails
- * @property {BN} utxoSize The size of the UTXO size in the redemption.
+ * @property {BN} utxoValue The value of the UTXO in the redemption.
  * @property {Buffer} redeemerOutputScript The raw redeemer output script bytes.
  * @property {BN} requestedFee The fee for the redemption transaction.
  * @property {Buffer} outpoint The raw outpoint bytes.
@@ -59,7 +59,7 @@ export default class Redemption {
     this.redemptionDetails = this.getLatestRedemptionDetails(redemptionDetails)
 
     this.unsignedTransactionDetails = this.redemptionDetails.then(details => {
-      const outputValue = details.utxoSize.sub(details.requestedFee)
+      const outputValue = details.utxoValue.sub(details.requestedFee)
       const unsignedTransaction = BitcoinHelpers.Transaction.constructOneInputOneOutputWitnessTransaction(
         details.outpoint.replace("0x", ""),
         // We set sequence to `0` to be able to replace by fee. It reflects
@@ -164,9 +164,9 @@ export default class Redemption {
             `chain for deposit ${this.deposit.address}...`
         )
 
-        const { utxoSize, requestedFee, redeemerOutputScript } = await this
+        const { utxoValue, requestedFee, redeemerOutputScript } = await this
           .redemptionDetails
-        const expectedValue = utxoSize.sub(requestedFee).toNumber()
+        const expectedValue = utxoValue.sub(requestedFee).toNumber()
         // FIXME Check that the transaction spends the right UTXO, not just
         // FIXME that it's the right amount to the right address. outpoint
         // FIXME compared against vin is probably the move here.


### PR DESCRIPTION
Update to use renamed contract method `utxoValue` instead of `utxoSize` and fix params for `tbtcToBtc` method.

Closes #51 