### PR TITLE
Adjust to rename in Deposit.signerFee

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -376,7 +376,7 @@ export default class Deposit {
    * @return {Promise<BN>} A promise to the signer fee for this deposit, in TBTC.
    */
   async getSignerFeeTBTC() {
-    return toBN(await this.contract.methods.signerFee().call())
+    return toBN(await this.contract.methods.signerFeeTbtc().call())
   }
 
   /**


### PR DESCRIPTION
The new name is signerFeeTbtc, which aligns with the tbtc.js method name
as well.

In draft until keep-network/tbtc#704, which implements this change, lands.