### PR TITLE
Get network id from artifact

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-import TBTC from "./src/TBTC.js"
+import TBTC, { getNetworkIdFromArtifact } from "./src/TBTC.js"
 import BitcoinHelpers from "./src/BitcoinHelpers.js"
 import EthereumHelpers from "./src/EthereumHelpers.js"
 
-export { BitcoinHelpers, EthereumHelpers }
+export { BitcoinHelpers, EthereumHelpers, getNetworkIdFromArtifact }
 
 /** @typedef { import("./src/Deposit.js").default } Deposit */
 /** @typedef { import("./src/Redemption.js").default } Redemption */

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -2,6 +2,7 @@ import { DepositFactory } from "./Deposit.js"
 import BitcoinHelpers from "./BitcoinHelpers.js"
 import BN from "bn.js"
 import { Constants } from "./Constants.js"
+import TBTCSystemJSON from "@keep-network/tbtc/artifacts/TBTCSystem.json"
 /** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork
 
 /**
@@ -96,4 +97,14 @@ export default {
     return await TBTC.withConfig(config, networkMatchCheck)
   },
   BitcoinNetwork: BitcoinHelpers.Network
+}
+
+/**
+ * Returns the network ID from the artifact.
+ * Artifacts from @keep-network/tbtc for a given build only support a single network id.
+ * 
+ * @return {string} network ID
+ */
+export const getNetworkIdFromArtifact = () => {
+  return Object.keys(TBTCSystemJSON.networks)[0]
 }


### PR DESCRIPTION
Ref: https://github.com/keep-network/tbtc-dapp/pull/205

Added a function that returns the network id from tbtc artifact. Artifacts from `@keep-network/tbtc` for a given build only support a single network id.