### PR TITLE
Notification Station: Pull in deposit API changes, plus fix two outstanding issues

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -392,7 +392,7 @@ export default class Deposit {
    * @return {DepositStates} The current state of the deposit.
    */
   async getCurrentState() {
-    return parseInt(await this.contract.methods.getCurrentState().call())
+    return parseInt(await this.contract.methods.currentState().call())
   }
 
   async getTDT() /* : Promise<TBTCDepositToken>*/ {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -287,11 +287,13 @@ export default class Deposit {
     const web3 = factory.config.web3
     const contract = new web3.eth.Contract(DepositJSON.abi, depositAddress)
     contract.options.from = web3.eth.defaultAccount
+    contract.options.handleRevert = true
     const keepContract = new web3.eth.Contract(
       BondedECDSAKeepJSON.abi,
       keepAddress
     )
     keepContract.options.from = web3.eth.defaultAccount
+    keepContract.options.handleRevert = true
 
     return new Deposit(factory, contract, keepContract)
   }
@@ -305,6 +307,7 @@ export default class Deposit {
     const web3 = factory.config.web3
     const contract = new web3.eth.Contract(DepositJSON.abi, address)
     contract.options.from = web3.eth.defaultAccount
+    contract.options.handleRevert = true
 
     console.debug(`Looking up Created event for deposit ${address}...`)
     const createdEvent = await EthereumHelpers.getExistingEvent(
@@ -325,6 +328,7 @@ export default class Deposit {
       keepAddress
     )
     keepContract.options.from = web3.eth.defaultAccount
+    keepContract.options.handleRevert = true
 
     return new Deposit(factory, contract, keepContract)
   }

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -221,8 +221,8 @@ export class DepositFactory {
 
     if (creationCost.lt(accountBalance)) {
       throw new Error(
-        `Insufficient balance ${accountBalance.toNumber()} to open ` +
-          `deposit (required: ${creationCost.toNumber()}).`
+        `Insufficient balance ${accountBalance.toString()} to open ` +
+          `deposit (required: ${creationCost.toString()}).`
       )
     }
 
@@ -273,7 +273,7 @@ export default class Deposit {
   static async forLotSize(factory, satoshiLotSize) {
     console.debug(
       "Creating new deposit contract with lot size",
-      satoshiLotSize.toNumber(),
+      satoshiLotSize.toString(),
       "satoshis..."
     )
     const {
@@ -670,8 +670,8 @@ export default class Deposit {
     if (redemptionCost.gt(availableBalance)) {
       throw new Error(
         `Account ${thisAccount} does not have the required balance of ` +
-          `${redemptionCost.toNumber()} to redeem; it only has ` +
-          `${availableBalance.toNumber()} available.`
+          `${redemptionCost.toString()} to redeem; it only has ` +
+          `${availableBalance.toString()} available.`
       )
     }
 

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -172,6 +172,7 @@ function getDeployedContract(artifact, web3, networkId) {
   const contract = new web3.eth.Contract(artifact.abi)
   contract.options.address = lookupAddress(artifact)
   contract.options.from = web3.eth.defaultAccount
+  contract.options.handleRevert = true
 
   return contract
 }


### PR DESCRIPTION
Each commit handles a different issue. It turns out the current tbtc.js doesn't
have a lot of exposure to the changed APIs from keep-network/tbtc#695, so
that fix was small enough to roll in a few miscellaneous ones as well.

Of note, #25 likely will need to be revised more for the aforementioned API
changes; that can be done in-PR, however.

Closes #20, closes #56, closes #57.