### PR TITLE
Replace obsolete getSatoshiLotSize usages

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ listen for the Bitcoin address and present it on the console:
 
 ```
 deposit.onBitcoinAddressAvailable(async (address) => {
-    const lotSize = await deposit.getSatoshiLotSize()
+    const lotSize = await deposit.getLotSizeSatoshis()
     console.log(
         "\tGot deposit address:", address,
         "; fund with:", lotSize.toString(), "satoshis please.",

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -384,7 +384,7 @@ export default class Deposit {
     return (this._fundingTransaction =
       this._fundingTransaction ||
       this.bitcoinAddress.then(async address => {
-        const expectedValue = await this.getSatoshiLotSize()
+        const expectedValue = await this.getLotSizeSatoshis()
         console.debug(
           `Monitoring Bitcoin for transaction to address ${address}...`
         )


### PR DESCRIPTION
`getSatoshiLotSize` method was renamed to `getLotSizeSatoshis`. However, there was two places which still used the old name and caused errors. Here we fix this problem.