### PR TITLE
Pr-etty linted: Run linting (and tests) on PRs

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ releases/ropsten/0.18.0-rc ]
+    branches: [ 'releases/**' ]
   pull_request:
-    branches: [ releases/ropsten/0.18.0-rc ]
+    branches: [ master ]
   repository_dispatch:
     types: redeploy
 
@@ -31,7 +31,7 @@ jobs:
     - run: npm test
       env:
         CI: true
-    - if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
+    - if: contains(github.ref, 'releases/ropsten')
       name: Bump and publish npm package
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,7 +8,7 @@ on:
     branches: [ 'releases/**' ]
   pull_request:
     branches: [ master ]
-  repository_dispatch:
+  workflow_dispatch:
     types: redeploy
 
 jobs:


### PR DESCRIPTION
Though there's a pre-commit config in the repo, and there is also an action
that handles linting and testing, the linting and testing is currently restricted
to run on release builds.

This PR runs linting and testing on all PRs, runs those + package publishing
on all pushes to a `releases/*` branch, and updates the `repository_dispatch`
trigger to be `workflow_dispatch` so it can be triggered from the GitHub UI.

Closes #61 .