### PR TITLE
Expose confirmations

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -355,9 +355,9 @@ const BitcoinHelpers = {
             transactionID
           )
 
-          typeof onReceivedConfirmation === "function" &&
-            confirmations &&
+          if (typeof onReceivedConfirmation === "function" && confirmations) {
             onReceivedConfirmation({ transactionID, confirmations })
+          }
 
           if (confirmations >= requiredConfirmations) {
             return confirmations

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -338,7 +338,7 @@ const BitcoinHelpers = {
      * @param {string} transactionID A hex Bitcoin transaction id hash.
      * @param {number} requiredConfirmations The number of required
      *        confirmations to wait before returning.
-     * @param {function} onReceivedConfirmation A callback that fires when a
+     * @param {function} [onReceivedConfirmation] A callback that fires when a
      *        confirmation is seen
      *
      * @return {Promise<number>} A promise to the final number of confirmations

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -315,7 +315,7 @@ const BitcoinHelpers = {
      * @param {number} requiredConfirmations A number of required
      *        confirmations below which this function will return null.
      * @param {function} [onReceivedConfirmation] A callback that fires when a
-     *        confirmation is seen
+     *        confirmation is seen.
      *
      * @return {Promise<number>} A promise to the current number of
      *         confirmations for the given `transaction`, iff that transaction has
@@ -348,7 +348,7 @@ const BitcoinHelpers = {
      * @param {number} requiredConfirmations The number of required
      *        confirmations to wait before returning.
      * @param {function} [onReceivedConfirmation] A callback that fires when a
-     *        confirmation is seen
+     *        confirmation is seen.
      *
      * @return {Promise<number>} A promise to the final number of confirmations
      *         observed that was at least equal to the required confirmations.

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -374,7 +374,7 @@ export default class Deposit {
       this.publicKeyPointToBitcoinAddress.bind(this)
     )
 
-    this.receivedConfirmationEmitter = new EventEmitter()
+    this.receivedFundingConfirmationEmitter = new EventEmitter()
   }
 
   // /------------------------------- Accessors -------------------------------
@@ -425,10 +425,13 @@ export default class Deposit {
           transaction.transactionID,
           requiredConfirmations,
           ({ transactionID, confirmations }) => {
-            this.receivedConfirmationEmitter.emit("receivedConfirmation", {
-              transactionID,
-              confirmations
-            })
+            this.receivedFundingConfirmationEmitter.emit(
+              "receivedFundingConfirmation",
+              {
+                transactionID,
+                confirmations
+              }
+            )
           }
         )
 
@@ -535,16 +538,16 @@ export default class Deposit {
 
   /**
    * Registers a handler for notification when the Bitcoin funding transaction
-   * has received a confirmation
+   * has received a confirmation.
    *
-   * @param {OnReceivedConfirmationHandler} onReceivedConfirmationHandler
-   *        A handler that passes an object with the transactionID and
-   *        confirmations as its parameter
+   * @param {OnReceivedFundingConfirmationHandler} onReceivedFundingConfirmationHandler
+   *        A handler that receives an object with the transactionID and
+   *        confirmations as its parameter.
    */
-  onReceivedConfirmation(onReceivedConfirmationHandler) {
-    this.receivedConfirmationEmitter.on(
-      "receivedConfirmation",
-      onReceivedConfirmationHandler
+  onReceivedFundingConfirmation(onReceivedFundingConfirmationHandler) {
+    this.receivedFundingConfirmationEmitter.on(
+      "receivedFundingConfirmation",
+      onReceivedFundingConfirmationHandler
     )
   }
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -622,7 +622,7 @@ export default class Deposit {
         .call()
     )
     const confirmations = await BitcoinHelpers.Transaction.checkForConfirmations(
-      tx,
+      tx.transactionID,
       requiredConfirmations
     )
     if (!confirmations) {


### PR DESCRIPTION
Expose `onReceivedConfirmation` events for both deposit and redemption flows. They take a handler that provides an object with the `transactionID` and current number of `confirmations` as its parameter. 

Closes #30 