### PR TITLE
Retry in case of retrieveSignerPubkey error

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -979,8 +979,11 @@ export default class Deposit {
       `Waiting for deposit ${this.address} to retrieve public key...`
     )
     // Ask the deposit to fetch and store the signer pubkey.
-    const pubkeyTransaction = await EthereumHelpers.sendSafely(
-      this.contract.methods.retrieveSignerPubkey()
+    const pubkeyTransaction = await EthereumHelpers.sendSafelyRetryable(
+      this.contract.methods.retrieveSignerPubkey(),
+      {},
+      false,
+      5
     )
 
     console.debug(`Found public key for deposit ${this.address}...`)

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -978,26 +978,10 @@ export default class Deposit {
     console.debug(
       `Waiting for deposit ${this.address} to retrieve public key...`
     )
-
-    let pubkeyTransaction
-
-    for (;;) {
-      try {
-        // Ask the deposit to fetch and store the signer pubkey.
-        console.debug(`Starting public key retrieval attempt...`)
-
-        pubkeyTransaction = await EthereumHelpers.sendSafely(
-          this.contract.methods.retrieveSignerPubkey()
-        )
-
-        if (pubkeyTransaction) {
-          break
-        }
-      } catch (e) {
-        console.debug("Could not retrieve signer public key; retrying", e)
-        await new Promise(resolve => setTimeout(resolve, 10000))
-      }
-    }
+    // Ask the deposit to fetch and store the signer pubkey.
+    const pubkeyTransaction = await EthereumHelpers.sendSafely(
+      this.contract.methods.retrieveSignerPubkey()
+    )
 
     console.debug(`Found public key for deposit ${this.address}...`)
     const {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -978,10 +978,26 @@ export default class Deposit {
     console.debug(
       `Waiting for deposit ${this.address} to retrieve public key...`
     )
-    // Ask the deposit to fetch and store the signer pubkey.
-    const pubkeyTransaction = await EthereumHelpers.sendSafely(
-      this.contract.methods.retrieveSignerPubkey()
-    )
+
+    let pubkeyTransaction
+
+    for (;;) {
+      try {
+        // Ask the deposit to fetch and store the signer pubkey.
+        console.debug(`Starting public key retrieval attempt...`)
+
+        pubkeyTransaction = await EthereumHelpers.sendSafely(
+          this.contract.methods.retrieveSignerPubkey()
+        )
+
+        if (pubkeyTransaction) {
+          break
+        }
+      } catch (e) {
+        console.debug("Could not retrieve signer public key; retrying", e)
+        await new Promise(resolve => setTimeout(resolve, 10000))
+      }
+    }
 
     console.debug(`Found public key for deposit ${this.address}...`)
     const {


### PR DESCRIPTION
The `retrieveSignerPubkey` transaction can fail if they occur immediately after receiving the `PublicKeyPublished` event and a load-balanced Ethereum client is used. This is because the contract state is propagated with a delay across all Ethereum nodes. There can be a situation when the `PublicKeyPublished` is received from one node but the `retrieveSignerPubkey` is executed against another one which isn't aware of the public key yet and will revert the transaction. To prevent breaking the whole deposit flow, we introduce a retry mechanism.