### PR TITLE
Configu-mania: Improve configuration handling in TBTC.withConfig

### DIFF
--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -5,6 +5,30 @@ import TBTC from "../index.js"
 import ProviderEngine from "web3-provider-engine"
 import Subproviders from "@0x/subproviders"
 
+/** @type {{ [name: string]: import("../src/TBTC.js").ElectrumConfig }} */
+const electrumConfigs = {
+  testnet: {
+    server: "electrumx-server.test.tbtc.network",
+    port: 8443,
+    protocol: "wss"
+  },
+  testnetTCP: {
+    server: "electrumx-server.test.tbtc.network",
+    port: 50002,
+    protocol: "ssl"
+  },
+  mainnet: {
+    server: "electrumx-server.tbtc.network",
+    port: 8443,
+    protocol: "wss"
+  },
+  mainnetTCP: {
+    server: "electrumx-server.tbtc.network",
+    port: 50002,
+    protocol: "ssl"
+  }
+}
+
 const engine = new ProviderEngine({ pollingInterval: 1000 })
 engine.addProvider(
   // For address 0x420ae5d973e58bc39822d9457bf8a02f127ed473.
@@ -93,23 +117,7 @@ async function runAction() {
   const tbtc = await TBTC.withConfig({
     web3: web3,
     bitcoinNetwork: "testnet",
-    electrum: {
-      testnet: {
-        server: "electrumx-server.test.tbtc.network",
-        port: 50002,
-        protocol: "ssl"
-      },
-      testnetPublic: {
-        server: "testnet1.bauerj.eu",
-        port: 50002,
-        protocol: "ssl"
-      },
-      testnetWS: {
-        server: "electrumx-server.test.tbtc.network",
-        port: 8443,
-        protocol: "wss"
-      }
-    }
+    electrum: electrumConfigs.testnet
   })
 
   return action(tbtc)

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -1,19 +1,19 @@
+import bcoin from "bcoin/lib/bcoin-browser.js"
 import secp256k1 from "bcrypto/lib/secp256k1.js"
+import BcryptoSignature from "bcrypto/lib/internal/signature.js"
 import BcoinPrimitives from "bcoin/lib/primitives/index.js"
 import BcoinScript from "bcoin/lib/script/index.js"
-import BcryptoSignature from "bcrypto/lib/internal/signature.js"
-const { KeyRing } = BcoinPrimitives
-const { Script } = BcoinScript
-
-import bcoin from "bcoin/lib/bcoin-browser.js"
 
 import { BitcoinSPV } from "./lib/BitcoinSPV.js"
+/** @typedef { import("./lib/BitcoinSPV.js").Proof } Proof */
 import { BitcoinTxParser } from "./lib/BitcoinTxParser.js"
 import ElectrumClient from "./lib/ElectrumClient.js"
+/** @typedef { import("./lib/ElectrumClient.js").Config } ElectrumConfig */
 
 import BN from "bn.js"
 
-/** @typedef { import("./lib/BitcoinSPV.js").Proof } Proof */
+const { KeyRing } = BcoinPrimitives
+const { Script } = BcoinScript
 
 /** @enum {string} */
 const BitcoinNetwork = {
@@ -56,7 +56,9 @@ const BitcoinHelpers = {
 
   Network: BitcoinNetwork,
 
+  /** @type {ElectrumConfig?} */
   electrumConfig: null,
+
   /**
    * Updates the config to use for Electrum client connections. Electrum is
    * the core mechanism used to interact with the Bitcoin blockchain.
@@ -210,9 +212,7 @@ const BitcoinHelpers = {
    * @template T
    */
   withElectrumClient: async function(block) {
-    const electrumClient = new ElectrumClient(
-      BitcoinHelpers.electrumConfig.testnetWS
-    )
+    const electrumClient = new ElectrumClient(BitcoinHelpers.electrumConfig)
 
     await electrumClient.connect()
 

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -1,3 +1,16 @@
+/** @typedef { import("web3").default } Web3 */
+
+/**
+ * Checks whether the given web3 instance is connected to Ethereum mainnet.
+ *
+ * @param {Web3} web3 The web3 instance whose network should be checked.
+ * @return {Promise<boolean>} True if the web3 instance is aimed at Ethereum
+ *         mainnet, false otherwise.
+ */
+async function isMainnet(web3) {
+  return (await web3.eth.getChainId()) == 0x1
+}
+
 /**
  * From a given transaction result, extracts the first event with the given
  * name from the given source contract.
@@ -178,6 +191,7 @@ function getDeployedContract(artifact, web3, networkId) {
 }
 
 export default {
+  isMainnet,
   getEvent,
   getExistingEvent,
   readEventFromTransaction,

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -1,9 +1,14 @@
-import { DepositFactory } from "./Deposit.js"
-import BitcoinHelpers from "./BitcoinHelpers.js"
 import BN from "bn.js"
+/** @typedef { import("web3").default } Web3 */
+
+import BitcoinHelpers from "./BitcoinHelpers.js"
+/** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork */
+import EthereumHelpers from "./EthereumHelpers.js"
+
+import { DepositFactory } from "./Deposit.js"
 import { Constants } from "./Constants.js"
+
 import TBTCSystemJSON from "@keep-network/tbtc/artifacts/TBTCSystem.json"
-/** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork
 
 /**
  * @typedef {Object} TBTCConfig
@@ -11,55 +16,34 @@ import TBTCSystemJSON from "@keep-network/tbtc/artifacts/TBTCSystem.json"
  * @prop {Web3} web3
  */
 
-/** @type {TBTCConfig} */
-const defaultConfig = {
-  bitcoinNetwork: BitcoinHelpers.Network.TESTNET,
-  web3: global.Web3
-}
-
 /**
- * @param {Web3} web3 The web3 instance
- * @return {boolean} True if the web3 instance is aimed at Ethereum mainnet,
- *         false otherwise.
+ * The entry point to the TBTC system. Call `TBTC.withConfig()` and pass the
+ * appropriate configuration object with web3, Bitcoin network, and Electrum
+ * information to receive an initialized instance of the `TBTC` class. The class
+ * then exposes two properties, `Deposit` and `Constants`. `Deposit` is a
+ * factory object for looking up and creating deposits, while `Constants` allows
+ * direct access to tBTC system constants.
  */
-function isMainnet(web3) {
-  return web3.currentProvider["chainId"] == 0x1
-}
-/**
- * @param {Web3} web3 The web3 instance
- * @return {boolean} True if the web3 instance is aimed at an Ethereum testnet,
- *         false otherwise.
- */
-function isTestnet(web3) {
-  return !isMainnet(web3)
-}
-
 export class TBTC {
-  static async withConfig(config = defaultConfig, networkMatchCheck = true) {
-    const depositFactory = await DepositFactory.withConfig(config)
-    const constants = await Constants.withConfig(config)
-    return new TBTC(depositFactory, constants, config, networkMatchCheck)
-  }
-
   /**
    *
-   * @param {DepositFactory} depositFactory
-   * @param {Constants} constants
-   * @param {TBTCConfig} config
-   * @param {boolean} networkMatchCheck
+   * @param {TBTCConfig} config The configuration to use for this instance.
+   * @param {boolean} [networkMatchCheck=true] When true, ensures that the
+   *        configured Bitcoin and Ethereum networks are either both mainnet or
+   *        both testnet.
    */
-  constructor(depositFactory, constants, config, networkMatchCheck = true) {
+  static async withConfig(config, networkMatchCheck = true) {
+    const ethereumMainnet = await EthereumHelpers.isMainnet(config.web3)
+    const bitcoinMainnet =
+      config.bitcoinNetwork == BitcoinHelpers.Network.MAINNET
+
     if (
       networkMatchCheck &&
-      ((isMainnet(config.web3) &&
-        config.bitcoinNetwork == BitcoinHelpers.Network.TESTNET) ||
-        (isMainnet(config.web3) &&
-          config.bitcoinNetwork == BitcoinHelpers.Network.SIMNET) ||
-        (isTestnet(config.web3) &&
-          config.bitcoinNetwork == BitcoinHelpers.Network.MAINNET))
+      ((ethereumMainnet && !bitcoinMainnet) ||
+        (!ethereumMainnet && bitcoinMainnet))
     ) {
       throw new Error(
-        `Ethereum network ${config.web3.currentProvider.chainId} ` +
+        `Ethereum network ${await config.web3.eth.getChainId()} ` +
           `and Bitcoin network ${config.bitcoinNetwork} are not both ` +
           `on testnet or both on  mainnet. Quitting while we're ` +
           `ahead. Developers can also pass false as the ` +
@@ -67,6 +51,18 @@ export class TBTC {
       )
     }
 
+    const depositFactory = await DepositFactory.withConfig(config)
+    const constants = await Constants.withConfig(config)
+    return new TBTC(depositFactory, constants, config)
+  }
+
+  /**
+   *
+   * @param {DepositFactory} depositFactory
+   * @param {Constants} constants
+   * @param {TBTCConfig} config
+   */
+  constructor(depositFactory, constants, config) {
     /** @package */
     this.depositFactory = depositFactory
     /** @package */

--- a/src/TBTC.js
+++ b/src/TBTC.js
@@ -4,6 +4,7 @@ import BN from "bn.js"
 import BitcoinHelpers from "./BitcoinHelpers.js"
 /** @typedef { import("./BitcoinHelpers.js").BitcoinNetwork } BitcoinNetwork */
 import EthereumHelpers from "./EthereumHelpers.js"
+/** @typedef { import("./lib/ElectrumClient.js").Config } ElectrumConfig */
 
 import { DepositFactory } from "./Deposit.js"
 import { Constants } from "./Constants.js"
@@ -11,9 +12,10 @@ import { Constants } from "./Constants.js"
 import TBTCSystemJSON from "@keep-network/tbtc/artifacts/TBTCSystem.json"
 
 /**
- * @typedef {Object} TBTCConfig
- * @prop {BitcoinNetwork} bitcoinNetwork
- * @prop {Web3} web3
+ * @typedef {object} TBTCConfig
+ * @property {Web3} web3
+ * @property {BitcoinNetwork} bitcoinNetwork
+ * @property {ElectrumConfig} electrum
  */
 
 /**

--- a/src/lib/ElectrumClient.js
+++ b/src/lib/ElectrumClient.js
@@ -4,12 +4,14 @@ const { digest } = sha256
 
 /**
  * Configuration of electrum client.
- * @typedef Config
- * @type {Object}
+ * @typedef {object} Config
  * @property {string} server ElectrumX server hostname.
  * @property {number} port ElectrumX server port.
- * @property {string} protocol ElectrumX server connection protocol
- * (`ssl`|`tls`|`ws`|`wss`).
+ * @property {"ssl"|"tls"|"ws"|"wss"} protocol The server connection protocol to
+ *           use for the specified `server`.
+ * @property {object} [options] Additional options for the server connection.
+ *           For WebSocket connections, these are `W3CWebSocket` options; for
+ *           SSL/TLS connections, they are Node `TLSSocket` options.
  */
 
 /**


### PR DESCRIPTION
Two big changes here:
- The `config.electrum` property now takes just the Electrum config you want to use, not a bundle of configs that we only use `testnetWS` from. This will require an update to tbtc-dapp to pass the correct object.
- Using proper APIs to get the Ethereum chain id during `TBTC.withConfig`. Mainnet verification has been moved to `EthereumHelpers.isMainnet`, and the logic for checking network matches is a little simpler.

Along the way, a few typing fixes and adjustments. Also some import reorg, so apologies for the noise there.

Closes #68. Refs #65.