### PR TITLE
Type-sy: Just a few types to drink

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,6 +4,8 @@
     "target": "es6",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "checkJs": true,
-  },
+    "maxNodeModuleJsDepth": 2,
+    "esModuleInterop": true,
+    "checkJs": true
+  }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "module": "es6",
-    "target": "es6"
+    "target": "es6",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "checkJs": true,
   },
-  "checkJs": true,
-  "exclude": ["node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,8 +2841,7 @@
         "big-integer": "^1.6.44",
         "chai": "^4.2.0",
         "mocha": "^6.2.2",
-        "ts-node": "^8.4.1",
-        "typescript": "^3.6.4"
+        "ts-node": "^8.4.1"
       }
     },
     "blst": {
@@ -22146,6 +22145,21 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+      "from": "github:web3-js/scrypt-shim",
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "scryptsy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
@@ -23188,9 +23202,10 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "dev": true
     },
     "u2f-api": {
       "version": "0.2.7",
@@ -23714,6 +23729,7 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
+        "scrypt-shim": "github:web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "test": "mocha --timeout 10000",
     "lint": "npm run lint:js",
     "lint:fix": "npm run lint:fix:js",
-    "lint:js": "eslint .",
-    "lint:fix:js": "eslint --fix ."
+    "lint:js": "npm run lint:js:eslint && npm run lint:js:types",
+    "lint:fix:js": "eslint --fix .",
+    "lint:js:eslint": "eslint .",
+    "lint:js:types": "!(npx tsc --allowJs --noEmit $(cat jsconfig.json | jq -r '.compilerOptions | to_entries | map([\"--\\(.key)\",.value]) | flatten | join(\" \")') src/**.js | grep \"^\\(src\\|bin\\|test\\|examples\\)/\") # comment any other passed arguments"
   },
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
   "license": "MIT",
@@ -47,6 +49,7 @@
     "eslint-config-keep": "git+https://github.com/keep-network/eslint-config-keep.git#0.3.0",
     "prettier": "^1.19.1",
     "fs": "0.0.1-security",
-    "mocha": "^6.2.0"
+    "mocha": "^6.2.0",
+    "typescript": "3.4.3"
   }
 }

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -16,7 +16,7 @@ const { KeyRing } = BcoinPrimitives
 const { Script } = BcoinScript
 
 /** @enum {string} */
-const BitcoinNetwork = {
+export const BitcoinNetwork = {
   TESTNET: "testnet",
   MAINNET: "mainnet",
   SIMNET: "simnet"

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,22 +1,27 @@
-import TBTCConstantsJSON from "@keep-network/tbtc/artifacts/TBTCConstants.json"
-import EthereumHelpers from "./EthereumHelpers.js"
 import web3Utils from "web3-utils"
-const { toBN } = web3Utils
+/** @typedef { import("web3-eth-contract").Contract } Contract */
+/** @typedef { import("bn.js") } BN */
 
-/** @typedef { import("web3").default.Web3.eth.Contract } Contract */
+import EthereumHelpers from "./EthereumHelpers.js"
+/** @typedef { import("./EthereumHelpers.js").TruffleArtifact } TruffleArtifact */
+/** @typedef { import("./TBTC.js").TBTCConfig } TBTCConfig */
+
+import TBTCConstantsJSON from "@keep-network/tbtc/artifacts/TBTCConstants.json"
+
+const { toBN } = web3Utils
 
 class Constants {
   /**
    * @param {TBTCConfig} config The config to use for this constants instance.
-   * @return {Constants} The TBTC constants.
+   * @return {Promise<Constants>} The TBTC constants.
    */
   static async withConfig(config) {
     const { web3 } = config
     const networkId = await web3.eth.net.getId()
     const tbtcConstantsContract = EthereumHelpers.getDeployedContract(
-      TBTCConstantsJSON,
+      /** @type {TruffleArtifact} */ (TBTCConstantsJSON),
       web3,
-      networkId
+      networkId.toString()
     )
 
     // BatchRequest makes a batch of Web3 RPC requests as one network payload.

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -168,7 +168,7 @@ export class DepositFactory {
       const contract = EthereumHelpers.getDeployedContract(
         artifact,
         web3,
-        networkId
+        networkId.toString()
       )
       this[propertyName] = contract
     })
@@ -240,8 +240,8 @@ export class DepositFactory {
       await this.systemContract.methods.getNewDepositFeeEstimate().call()
     )
 
-    const accountBalance = await this.config.web3.eth.getBalance(
-      this.config.web3.eth.defaultAccount
+    const accountBalance = toBN(
+      await this.config.web3.eth.getBalance(this.config.web3.eth.defaultAccount)
     )
 
     if (creationCost.lt(accountBalance)) {
@@ -410,7 +410,10 @@ export default class Deposit {
         console.debug(
           `Monitoring Bitcoin for transaction to address ${address}...`
         )
-        return BitcoinHelpers.Transaction.findOrWaitFor(address, expectedValue)
+        return BitcoinHelpers.Transaction.findOrWaitFor(
+          address,
+          expectedValue.toNumber()
+        )
       }))
   }
 
@@ -661,7 +664,7 @@ export default class Deposit {
     )
     const proofArgs = await this.constructFundingProof(
       tx,
-      parseInt(requiredConfirmations)
+      requiredConfirmations
     )
     proofArgs.unshift(this.address)
 
@@ -686,7 +689,7 @@ export default class Deposit {
       "Transfer"
     )
 
-    return toBN(transferEvent.value).div(toBN(10).pow(18))
+    return toBN(transferEvent.value).div(toBN(10).pow(toBN(18)))
   }
 
   /**
@@ -986,7 +989,7 @@ export default class Deposit {
         )
         console.debug(`Minted`, transferEvent.value, `TBTC.`)
 
-        return toBN(transferEvent.value).div(toBN(10).pow(18))
+        return toBN(transferEvent.value).div(toBN(10).pow(toBN(18)))
       }
     )
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -2,6 +2,7 @@ import EventEmitter from "events"
 
 import BitcoinHelpers from "./BitcoinHelpers.js"
 /** @typedef { import("./BitcoinHelpers.js").TransactionInBlock } BitcoinTransaction */
+/** @typedef { import("./BitcoinHelpers.js").OnReceivedConfirmationHandler } OnReceivedConfirmationHandler */
 
 import EthereumHelpers from "./EthereumHelpers.js"
 
@@ -561,7 +562,7 @@ export default class Deposit {
    * Registers a handler for notification when the Bitcoin funding transaction
    * has received a confirmation.
    *
-   * @param {OnReceivedFundingConfirmationHandler} onReceivedFundingConfirmationHandler
+   * @param {OnReceivedConfirmationHandler} onReceivedFundingConfirmationHandler
    *        A handler that receives an object with the transactionID and
    *        confirmations as its parameter.
    */

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -247,7 +247,7 @@ export class DepositFactory {
       await this.config.web3.eth.getBalance(this.config.web3.eth.defaultAccount)
     )
 
-    if (creationCost.lt(accountBalance)) {
+    if (creationCost.gt(accountBalance)) {
       throw new Error(
         `Insufficient balance ${accountBalance.toString()} to open ` +
           `deposit (required: ${creationCost.toString()}).`

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -668,7 +668,6 @@ export default class Deposit {
       tx,
       requiredConfirmations
     )
-    proofArgs.unshift(this.address)
 
     // Use approveAndCall pattern to execute VendingMachine.unqualifiedDepositToTbtc.
     const unqualifiedDepositToTbtcCall = this.factory.vendingMachineContract.methods

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1253,9 +1253,10 @@ export default class Deposit {
    * Purchases the signer bonds and closes the liquidation auction.
    */
   async purchaseSignerBondsAtAuction() {
+    // FIXME Need systemic handling of default from address.
     const owner = this.factory.config.web3.eth.defaultAccount
     const allowance = await this.factory.tokenContract.methods
-      .allowance(owner, deposit.address)
+      .allowance(owner, this.address)
       .call()
 
     const lotSize = await this.getLotSizeTBTC()

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -493,7 +493,7 @@ export default class Deposit {
   }
 
   /**
-   * @return {DepositStates} The current state of the deposit.
+   * @return {Promise<DepositStates>} The current state of the deposit.
    */
   async getCurrentState() {
     return parseInt(await this.contract.methods.currentState().call())
@@ -1159,7 +1159,7 @@ export default class Deposit {
   /**
    * Get the current collateralization level for this Deposit.
    * Collateralization will be 0% if the deposit is in liquidation.
-   * @return {BN} Percentage collateralization, as an integer. eg. 149%
+   * @return {Promise<BN>} Percentage collateralization, as an integer. eg. 149%
    */
   async getCollateralizationPercentage() {
     return toBN(
@@ -1169,7 +1169,7 @@ export default class Deposit {
 
   /**
    * Get the initial collateralization level for this Deposit.
-   * @return {BN} Percentage collateralization, as an integer. eg. 150%
+   * @return {Promise<BN>} Percentage collateralization, as an integer. eg. 150%
    */
   async getInitialCollateralizedPercentage() {
     return toBN(
@@ -1182,7 +1182,7 @@ export default class Deposit {
    * If the collateralization level falls below this percentage, the Deposit can
    * get courtesy-called.
    * The deposit can be courtesy called using `Deposit.notifyCourtesyCall`.
-   * @return {BN} Percentage collateralization, as an integer. eg. 125%
+   * @return {Promise<BN>} Percentage collateralization, as an integer. eg. 125%
    */
   async getUndercollateralizedThresholdPercent() {
     return toBN(
@@ -1195,7 +1195,7 @@ export default class Deposit {
    * If the collateralization level falls below this percentage, the Deposit
    * can be liquidated.
    * Liquidation can be initiated using `Deposit.notifyUndercollateralizedLiquidation`.
-   * @return {BN} Percentage collateralization, as an integer. eg. 110%
+   * @return {Promise<BN>} Percentage collateralization, as an integer. eg. 110%
    */
   async getSeverelyUndercollateralizedThresholdPercent() {
     return toBN(
@@ -1273,7 +1273,7 @@ export default class Deposit {
   /**
    * Gets the current value of signer bonds at auction.
    * Only callable if the deposit is in the liqudation state.
-   * @return {BN} auction value in wei.
+   * @return {Promise<BN>} auction value in wei.
    */
   async auctionValue() {
     return toBN(await this.contract.methods.auctionValue().call())
@@ -1334,7 +1334,7 @@ export default class Deposit {
   /**
    * Checks if signature was requested via the Keep.
    * @param {string} digest Digest to check approval for.
-   * @return {boolean} True if signature approved, false if not (fraud).
+   * @return {Promise<boolean>} True if signature approved, false if not (fraud).
    */
   async wasSignatureApproved(digest) {
     const events = await this.keepContract.getPastEvents("SignatureRequested", {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -388,8 +388,8 @@ export default class Deposit {
     this.activeStatePromise = this.waitForActiveState()
 
     this.publicKeyPoint = this.findOrWaitForPublicKeyPoint()
-    this.bitcoinAddress = this.publicKeyPoint.then(
-      this.publicKeyPointToBitcoinAddress.bind(this)
+    this.bitcoinAddress = this.publicKeyPoint.then(point =>
+      this.publicKeyPointToBitcoinAddress(point)
     )
 
     this.receivedFundingConfirmationEmitter = new EventEmitter()

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -226,7 +226,7 @@ export class DepositFactory {
   }
 
   /**
-   * @private
+   * @package
    *
    * INTERNAL USE ONLY
    *

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -10,6 +10,7 @@ import EthereumHelpers from "./EthereumHelpers.js"
 /** @typedef { import("./EthereumHelpers.js").TransactionReceipt } TransactionReceipt */
 
 import Redemption from "./Redemption.js"
+/** @typedef { import("./Redemption.js").RedemptionDetails } RedemptionDetails */
 
 import TBTCConstantsJSON from "@keep-network/tbtc/artifacts/TBTCConstants.json"
 import TBTCSystemJSON from "@keep-network/tbtc/artifacts/TBTCSystem.json"
@@ -860,6 +861,8 @@ export default class Deposit {
    *
    * Returns a promise to the redemption details, or to null if there is no
    * current redemption in progress.
+   *
+   * @return {Promise<RedemptionDetails>}
    */
   async getLatestRedemptionDetails() {
     // If the contract is ACTIVE, there's definitely no redemption. This can
@@ -1135,9 +1138,11 @@ export default class Deposit {
     ]
   }
 
-  redemptionDetailsFromEvent(
-    redemptionRequestedEventArgs
-  ) /* : RedemptionDetails*/ {
+  /**
+   * @param {any} redemptionRequestedEventArgs
+   * @return {RedemptionDetails}
+   */
+  redemptionDetailsFromEvent(redemptionRequestedEventArgs) {
     const {
       _utxoValue,
       _redeemerOutputScript,

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1,12 +1,13 @@
-import EventEmitter from "events"
+import { EventEmitter } from "events"
 
 import BitcoinHelpers from "./BitcoinHelpers.js"
 /** @typedef { import("./BitcoinHelpers.js").TransactionInBlock } BitcoinTransaction */
 /** @typedef { import("./BitcoinHelpers.js").OnReceivedConfirmationHandler } OnReceivedConfirmationHandler */
 
 import EthereumHelpers from "./EthereumHelpers.js"
-
-/** @typedef { import("web3").default.Web3.eth.Contract } Contract */
+/** @typedef { import("./EthereumHelpers.js").Contract } Contract */
+/** @typedef { import("./EthereumHelpers.js").TruffleArtifact } TruffleArtifact */
+/** @typedef { import("./EthereumHelpers.js").TransactionReceipt } TransactionReceipt */
 
 import Redemption from "./Redemption.js"
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -362,10 +362,10 @@ export default class Deposit {
 
   /**
    * @param {DepositFactory} factory
-   * @param {any | string} tdt
+   * @param {string} tdtId
    */
-  static async forTDT(factory, tdt) {
-    return new Deposit(factory, "")
+  static async forTDT(factory, tdtId) {
+    return this.forAddress(factory, "0x" + toBN(tdtId).toString("hex"))
   }
 
   /**

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -888,8 +888,8 @@ export default class Deposit {
   /**
    * @typedef {Object} AutoSubmitState
    * @prop {Promise<BitcoinTransaction>} fundingTransaction
-   * @prop {Promise<{ transaction: FoundTransaction, requiredConfirmations: Number }>} fundingConfirmations
-   * @prop {Promise<EthereumTransaction>} proofTransaction
+   * @prop {Promise<{ transaction: BitcoinTransaction, requiredConfirmations: Number }>} fundingConfirmations
+   * @prop {Promise<TransactionReceipt>} proofTransaction
    * @prop {Promise<number>} mintedTBTC
    */
   /**

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -370,8 +370,8 @@ export default class Deposit {
 
   /**
    * @param {DepositFactory} factory
-   * @param {TruffleContract} depositContract
-   * @param {TruffleContract} keepContract
+   * @param {Contract} depositContract
+   * @param {Contract} keepContract
    */
   constructor(factory, depositContract, keepContract) {
     if (!keepContract) {

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -1,6 +1,7 @@
 import EventEmitter from "events"
 
 import BitcoinHelpers from "./BitcoinHelpers.js"
+/** @typedef { import("./BitcoinHelpers.js").OnReceivedConfirmationHandler } OnReceivedConfirmationHandler */
 
 import EthereumHelpers from "./EthereumHelpers.js"
 

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -22,7 +22,7 @@ const { toBN } = web3Utils
  * Details of a given unsigned transaction
  * @typedef {Object} UnsignedTransactionDetails
  * @property {string} hex The raw transaction hex string.
- * @property {digest} digest The transaction's digest.
+ * @property {string} digest The transaction's digest as a hex string.
  */
 
 /**
@@ -58,8 +58,10 @@ export default class Redemption {
     this.withdrawnEmitter = new EventEmitter()
     this.receivedConfirmationEmitter = new EventEmitter()
 
+    /** @type {Promise<RedemptionDetails>} */
     this.redemptionDetails = this.getLatestRedemptionDetails(redemptionDetails)
 
+    /** @type {Promise<UnsignedTransactionDetails>} */
     this.unsignedTransactionDetails = this.redemptionDetails.then(details => {
       const outputValue = details.utxoValue.sub(details.requestedFee)
       const unsignedTransaction = BitcoinHelpers.Transaction.constructOneInputOneOutputWitnessTransaction(

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -258,7 +258,7 @@ export default class Redemption {
       confirmations
     )
 
-    await EthereumHelpers.sendSafely(
+    const proofReceipt = EthereumHelpers.sendSafely(
       this.deposit.contract.methods.provideRedemptionProof(
         // Redemption proof does not take the output position as a
         // parameter, as all redemption transactions are one-input-one-output
@@ -269,7 +269,11 @@ export default class Redemption {
       )
     )
 
-    this.withdrawnEmitter.emit("withdrawn", transactionID)
+    proofReceipt.then(() =>
+      this.withdrawnEmitter.emit("withdrawn", transactionID)
+    )
+
+    return proofReceipt
   }
 
   onBitcoinTransactionSigned(transactionHandler /* : (transaction)=>void*/) {

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -11,10 +11,10 @@ const { toBN } = web3Utils
  * Details of a given redemption at a given point in time.
  * @typedef {Object} RedemptionDetails
  * @property {BN} utxoValue The value of the UTXO in the redemption.
- * @property {Buffer} redeemerOutputScript The raw redeemer output script bytes.
+ * @property {string} redeemerOutputScript The raw redeemer output script bytes.
  * @property {BN} requestedFee The fee for the redemption transaction.
- * @property {Buffer} outpoint The raw outpoint bytes.
- * @property {Buffer} digest The raw digest bytes.
+ * @property {string} outpoint The raw outpoint bytes.
+ * @property {string} digest The raw digest bytes.
  */
 
 /**


### PR DESCRIPTION
This PR cleans up and refines types across the public tbtc.js API
surface, and adds a tsc-based linting step that checks types before
commits go through. Right now only the src/ directory is linted, but
the examples and bin directories will be close behind.

Additionally, the new `jsconfig.json` should be enough to have VS
Code and other JS language server users apply proper type-checking
throughout the project.

Draft until #70 lands.

See #65 .