### PR TITLE
Type Bins: Add bin/ and examples/ to type checking

### DIFF
--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -55,7 +55,7 @@ if (process.argv[0].includes("tbtc.js")) {
   args = process.argv.slice(1) // invoked directly, no node
 }
 
-/** @type {(tbtc: TBTCInstance)=>Promise<string>} */
+/** @type {((tbtc: TBTCInstance)=>Promise<string>) | null} */
 let action = null
 
 switch (args[0]) {
@@ -96,7 +96,7 @@ switch (args[0]) {
     break
 }
 
-if (!action) {
+if (action === null) {
   console.log(`
 Unknown command ${args[0]} or bad parameters. Supported commands:
     deposit <lot-size-satoshis> [--no-mint]
@@ -122,7 +122,11 @@ Unknown command ${args[0]} or bad parameters. Supported commands:
   process.exit(1)
 }
 
-async function runAction() {
+/**
+ * @param {(function(TBTCInstance): Promise<string>)} action
+ * @return {Promise<string>}
+ */
+async function runAction(action) {
   web3.eth.defaultAccount = (await web3.eth.getAccounts())[0]
 
   const tbtc = await TBTC.withConfig({
@@ -134,7 +138,7 @@ async function runAction() {
   return action(tbtc)
 }
 
-runAction()
+runAction(action)
   .then(result => {
     console.log("Action completed with final result:", result)
 

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node --experimental-modules
-import Web3 from "web3"
-import TBTC from "../index.js"
-
-import ProviderEngine from "web3-provider-engine"
 import Subproviders from "@0x/subproviders"
+import Web3 from "web3"
+import ProviderEngine from "web3-provider-engine"
+import TBTC from "../index.js"
+/** @typedef {import('../src/TBTC.js').ElectrumConfig} ElectrumConfig */
+/** @typedef {import('../src/TBTC.js').TBTC} TBTCInstance */
 
-/** @type {{ [name: string]: import("../src/TBTC.js").ElectrumConfig }} */
+/** @type {{ [name: string]: ElectrumConfig }} */
 const electrumConfigs = {
   testnet: {
     server: "electrumx-server.test.tbtc.network",
@@ -51,6 +52,8 @@ let args = process.argv.slice(2)
 if (process.argv[0].includes("tbtc.js")) {
   args = process.argv.slice(1) // invoked directly, no node
 }
+
+/** @type {(tbtc: TBTCInstance)=>Promise<string>} */
 let action = null
 
 switch (args[0]) {

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -55,24 +55,30 @@ let action = null
 
 switch (args[0]) {
   case "deposit":
-    if (args.length == 2 && bnOrNull(args[1])) {
+    {
       let mint = true
       if (args.length == 3 && args[2] == "--no-mint") {
         mint = false
+        args.pop() // drop --no-mint
       }
-      action = async tbtc => {
-        return await createDeposit(tbtc, web3.utils.toBN(args[1]), mint)
+      if (args.length == 2 && bnOrNull(args[1])) {
+        action = async tbtc => {
+          return await createDeposit(tbtc, web3.utils.toBN(args[1]), mint)
+        }
       }
     }
     break
   case "resume":
-    if (args.length == 2 && web3.utils.isAddress(args[1])) {
+    {
       let mint = true
       if (args.length == 3 && args[2] == "--no-mint") {
         mint = false
+        args.pop() // drop --no-mint
       }
-      action = async tbtc => {
-        return await resumeDeposit(tbtc, args[1], mint)
+      if (args.length == 2 && web3.utils.isAddress(args[1])) {
+        action = async tbtc => {
+          return await resumeDeposit(tbtc, args[1], mint)
+        }
       }
     }
     break

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -44,6 +44,8 @@ engine.addProvider(
 )
 
 // -------------------------------- SETUP --------------------------------------
+// @ts-ignore Web3's provider interface seems to be inaccurate with respect to
+// what actually works, since ProviderEngine works just fine here.
 const web3 = new Web3(engine)
 engine.start()
 

--- a/examples/deposit.js
+++ b/examples/deposit.js
@@ -17,6 +17,9 @@ async function runExample() {
       "https://:e18ef5ef295944928dd87411bc678f19@ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
     )
   )
+
+  // @ts-ignore Web3's provider interface seems to be inaccurate with respect to
+  // what actually works, since ProviderEngine works just fine here.
   const web3 = new Web3(engine)
   engine.start()
 
@@ -26,21 +29,9 @@ async function runExample() {
     web3: web3,
     bitcoinNetwork: "testnet",
     electrum: {
-      testnet: {
-        server: "electrumx-server.test.tbtc.network",
-        port: 50002,
-        protocol: "ssl"
-      },
-      testnetPublic: {
-        server: "testnet1.bauerj.eu",
-        port: 50002,
-        protocol: "ssl"
-      },
-      testnetWS: {
-        server: "electrumx-server.test.tbtc.network",
-        port: 8443,
-        protocol: "wss"
-      }
+      server: "electrumx-server.test.tbtc.network",
+      port: 8443,
+      protocol: "wss"
     }
   })
 

--- a/examples/redeem.js
+++ b/examples/redeem.js
@@ -17,6 +17,9 @@ async function runExample() {
       "https://:e18ef5ef295944928dd87411bc678f19@ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
     )
   )
+
+  // @ts-ignore Web3's provider interface seems to be inaccurate with respect to
+  // what actually works, since ProviderEngine works just fine here.
   const web3 = new Web3(engine)
   engine.start()
 
@@ -26,11 +29,9 @@ async function runExample() {
     web3: web3,
     bitcoinNetwork: "simnet",
     electrum: {
-      testnetWS: {
-        server: "127.0.0.1",
-        port: 50003,
-        protocol: "ws"
-      }
+      server: "127.0.0.1",
+      port: 50003,
+      protocol: "ws"
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:js": "npm run lint:js:eslint && npm run lint:js:types",
     "lint:fix:js": "eslint --fix .",
     "lint:js:eslint": "eslint .",
-    "lint:js:types": "!(npx tsc --allowJs --noEmit $(cat jsconfig.json | jq -r '.compilerOptions | to_entries | map([\"--\\(.key)\",.value]) | flatten | join(\" \")') src/**.js | grep \"^\\(src\\|bin\\|test\\|examples\\)/\") # comment any other passed arguments"
+    "lint:js:types": "!(npx tsc --allowJs --noEmit $(cat jsconfig.json | jq -r '.compilerOptions | to_entries | map([\"--\\(.key)\",.value]) | flatten | join(\" \")') src/**.js bin/**.js examples/**.js | grep \"^\\(src\\|bin\\|test\\|examples\\)/\") # comment any other passed arguments"
   },
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
   "license": "MIT",


### PR DESCRIPTION
As promised, this adds the remaining files to type checking and to type
linting. This is mostly mechanical at this point, with only a few adjustments
to allow for types to propagate correctly and a couple of logic fixes that
TypeScript flagged.

In draft until #74 lands.

Closes #65 .