### PR TITLE
Futile Reasoning: Finally functioning support for revert reasons in sendSafely

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -258,8 +258,7 @@ export class DepositFactory {
 
     const result = await EthereumHelpers.sendSafely(
       this.depositFactory().methods.createDeposit(lotSize.toString()),
-      { value: creationCost },
-      true
+      { value: creationCost }
     )
 
     const createdEvent = EthereumHelpers.readEventFromTransaction(

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -193,7 +193,19 @@ async function sendSafely(boundContractMethod, sendParams, forceSend) {
         ...sendParams
       })
     } else {
-      throw exception // rethrow the exception if we don't handle it
+      // If we're not force-sending, use `call` to throw the true error reason
+      // (`estimateGas` doesn't return error messages, it only throws an
+      // out-of-gas).
+      // @ts-ignore A newer version of Web3 is needed to include call in TS.
+      await boundContractMethod.call({
+        from: "",
+        ...sendParams
+      })
+
+      // If `call` doesn't throw an error, something has gone quite awry; since
+      // we couldn't estimate gas, throw the original exception, since that's
+      // where things first went sideways.
+      throw exception
     }
   }
 }


### PR DESCRIPTION
The code here has lurched back and forth a little bit, but this finally lands
on an incantation that does the trick. `handleRevert` on contracts ensures
that, when `call` or `submit` run into a revert, they will report the reason
the contract mentioned for the revert in the error they throw. This is actually
carried in the `reason` property of the error, not in the `message` property.

To fully leverage this functionality, `sendSafely` now performs a `call` if gas
estimation fails, so the `call` can throw an exception with the complete revert
information. If `call` does not throw an exception, `sendSafely` throws the
original error from gas estimation, since no gas estimate is still considered an
error. Both of these functions are turned off if `forceSend` is passed in as `true`;
in this case, failed gas estimation simply submits a transaction with no gas
limit. If the transaction fails, it will throw an error which can include a revert
reason when appropriate. Unlike `call`, submitting the transaction will spend gas.

There was one place that was passing `forceSubmit` as `true` already, deposit
creation. This is no longer happening, so internal calls at the moment are
not passing `forceSubmit` anywhere. This should allow revert reasons to bubble
out without suffering any accidental gas expenditures.