### PR TITLE
Expose required confirmations

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -74,9 +74,10 @@ export const BitcoinNetwork = {
  * transaction id.
  *
  * @callback OnReceivedConfirmationHandler
- * @param {{ transactionID: string, confirmations: number }} confirmationInfo
- *        The transaction id whose confirmation was received, and the
- *        total number of confirmations seen for that transaction id.
+ * @param {{ transactionID: string, confirmations: number, requiredConfirmations: number }} confirmationInfo
+ *        The transaction id whose confirmation was received, the
+ *        total number of confirmations seen for that transaction id,
+ *        and the required confirmations for that transaction id.
  */
 
 const BitcoinHelpers = {
@@ -425,7 +426,11 @@ const BitcoinHelpers = {
             )
 
             if (typeof onReceivedConfirmation === "function" && confirmations) {
-              onReceivedConfirmation({ transactionID, confirmations })
+              onReceivedConfirmation({
+                transactionID,
+                confirmations,
+                requiredConfirmations
+              })
             }
 
             if (confirmations >= requiredConfirmations) {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -454,12 +454,13 @@ export default class Deposit {
         await BitcoinHelpers.Transaction.waitForConfirmations(
           transaction.transactionID,
           requiredConfirmations,
-          ({ transactionID, confirmations }) => {
+          ({ transactionID, confirmations, requiredConfirmations }) => {
             this.receivedFundingConfirmationEmitter.emit(
               "receivedFundingConfirmation",
               {
                 transactionID,
-                confirmations
+                confirmations,
+                requiredConfirmations
               }
             )
           }
@@ -571,8 +572,8 @@ export default class Deposit {
    * has received a confirmation.
    *
    * @param {OnReceivedConfirmationHandler} onReceivedFundingConfirmationHandler
-   *        A handler that receives an object with the transactionID and
-   *        confirmations as its parameter.
+   *        A handler that receives an object with the transactionID,
+   *        confirmations, and requiredConfirmations as its parameter.
    */
   onReceivedFundingConfirmation(onReceivedFundingConfirmationHandler) {
     this.receivedFundingConfirmationEmitter.on(

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -425,6 +425,26 @@ export default class Deposit {
   }
 
   /**
+   * Promise to the required number of confirmations.
+   * @return {Promise<number>}
+   */
+  get requiredConfirmations() {
+    // Lazily initialized.
+    this._requiredConfirmations =
+      this._requiredConfirmations ||
+      (async () => {
+        return parseInt(
+          await this.factory
+            .constants()
+            .methods.getTxProofDifficultyFactor()
+            .call()
+        )
+      })()
+
+    return this._requiredConfirmations
+  }
+
+  /**
    * @typedef FundingConfirmations
    * @type {Object}
    * @property {BitcoinTransaction} transaction
@@ -440,12 +460,7 @@ export default class Deposit {
     this._fundingConfirmations =
       this._fundingConfirmations ||
       this.fundingTransaction.then(async transaction => {
-        const requiredConfirmations = parseInt(
-          await this.factory
-            .constants()
-            .methods.getTxProofDifficultyFactor()
-            .call()
-        )
+        const requiredConfirmations = await this.requiredConfirmations
 
         console.debug(
           `Waiting for ${requiredConfirmations} confirmations for ` +

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -206,10 +206,11 @@ export default class Redemption {
       await BitcoinHelpers.Transaction.waitForConfirmations(
         transactionID,
         requiredConfirmations,
-        ({ transactionID, confirmations }) => {
+        ({ transactionID, confirmations, requiredConfirmations }) => {
           this.receivedConfirmationEmitter.emit("receivedConfirmation", {
             transactionID,
-            confirmations
+            confirmations,
+            requiredConfirmations
           })
         }
       )
@@ -325,8 +326,8 @@ export default class Redemption {
    * has received a confirmation
    *
    * @param {OnReceivedConfirmationHandler} onReceivedConfirmationHandler
-   *        A handler that passes an object with the transactionID and
-   *        confirmations as its parameter
+   *        A handler that passes an object with the transactionID,
+   *        confirmations, and requiredConfirmations as its parameter
    */
   onReceivedConfirmation(onReceivedConfirmationHandler) {
     this.receivedConfirmationEmitter.on(

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -192,12 +192,7 @@ export default class Redemption {
     )
 
     const confirmations = broadcastTransactionID.then(async transactionID => {
-      const requiredConfirmations = parseInt(
-        await this.deposit.factory
-          .constants()
-          .methods.getTxProofDifficultyFactor()
-          .call()
-      )
+      const requiredConfirmations = await this.deposit.requiredConfirmations
 
       console.debug(
         `Waiting for ${requiredConfirmations} confirmations for ` +


### PR DESCRIPTION
Provides the required number of confirmations as part of the event handler for the `OnReceivedConfirmation` events. Also adds a getter to the deposit so that `requiredConfirmations` is easily accessible.