### PR TITLE
Slick Moves: Add REGTEST network option

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -21,7 +21,8 @@ const { Script } = BcoinScript
 export const BitcoinNetwork = {
   TESTNET: "testnet",
   MAINNET: "main",
-  SIMNET: "simnet"
+  SIMNET: "simnet",
+  REGTEST: "regtest"
 }
 
 /**


### PR DESCRIPTION
This is used in the local-setup repo to spin up a local version of the
system.

Upstream of keep-network/local-setup#40. Anyone can merge.