### PR TITLE
Binary Situations

### DIFF
--- a/bin/commands/deposit.js
+++ b/bin/commands/deposit.js
@@ -160,7 +160,7 @@ export function parseDepositCommand(web3, args) {
               ? tbtc.depositFactory.vendingMachine().options.address
               : explicitAddress !== null
               ? explicitAddress
-              : web3.defaultAccount
+              : web3.eth.defaultAccount
 
             return listDeposits(tbtc, address)
           }

--- a/bin/commands/deposit.js
+++ b/bin/commands/deposit.js
@@ -1,0 +1,618 @@
+/** @typedef {import('../tbtc.js').CommandAction} CommandAction */
+/** @typedef {import('../../src/TBTC.js').ElectrumConfig} ElectrumConfig */
+/** @typedef {import('../../src/TBTC.js').Web3} Web3 */
+/** @typedef {import('../../src/TBTC.js').TBTC} TBTCInstance */
+/** @typedef {import('../../src/Deposit.js').default} Deposit */
+/** @typedef {import('../../src/Deposit.js').RedemptionDetails} RedemptionDetails */
+/** @typedef {import('bn.js')} BN */
+
+import EthereumHelpers from "../../src/EthereumHelpers.js"
+import Redemption from "../../src/Redemption.js"
+import { DepositStates } from "../../src/Deposit.js"
+import {
+  findAndConsumeArgExistence,
+  findAndConsumeArgsExistence,
+  findAndConsumeArgsValues
+} from "../helpers.js"
+
+export const depositCommandHelp = [
+  `new [--no-mint] <lot-size-satoshis>
+    Initiates a deposit funding flow. Takes the lot size in satoshis.
+    Will prompt with a Bitcoin address when funding needs to be
+    submitted. When the flow completes, outputs the deposit as a single
+    tab-delimited line with the deposit address, current deposit state,
+    the deposit lot size in satoshis, and, when applicable, the minted
+    amount of TBTC.
+
+    --no-mint
+        Specifies not to mint TBTC once the deposit is qualified.`,
+  `list [--vending-machine] [--address <address>]
+    With no options, lists the deposits currently owned by the web3
+    account address. Deposits are output as tab-delimited lines that
+    include the deposit address, current deposit state, and deposit
+    lot size in satoshis.
+
+    --vending-machine
+        Lists the deposits currently owned by the vending machine.
+
+    --address <address>
+        Lists the deposits currently owned by the specified address.`,
+  `<address> [<resume|redeem|liquidate|withdraw>]
+    Operations on a particular address. If no command is provided,
+    outputs the deposit as a single tab-delimited line with the deposit
+    address, current deposit state, and deposit lot size in satoshis.
+
+    resume [--funding|--redemption] [--no-mint]
+        Resumes a funding or redemption flow, depending on the deposit's
+        current state. When the flow completes, outputs the deposit as a
+        single tab-delimited line with the deposit address, current
+        deposit state, and deposit lot size in satoshis.
+
+        --funding
+            Only resumes the funding flow and outputs the final deposit
+            state; if the deposit is not mid-funding, does not resume and
+            outputs an error.
+
+            --no-mint
+                When resuming a funding flow, if the deposit is not already
+                mid-minting, specifies not to mint TBTC once the deposit is
+                qualified.
+
+        --redemption
+            Only resumes a flow if it is a redemption flow and outputs
+            the final deposit state; if the deposit is not mid-redemption,
+            does not resume and outputs an error.
+
+    redeem <bitcoin-address>
+        Initiates a deposit redemption flow that will redeem the deposit's
+        BTC to the specified Bitcoin address. When the flow completes,
+        outputs the deposit as a single tab-delimited line with the
+        deposit address, current deposit state, deposit lot size in
+        satoshis, and the transaction hash of the redemption Bitcoin
+        transaction.
+
+    courtesy-call
+        Attempts to notify the deposit it is undercollateralized and
+        should transition into courtesy call.
+
+    liquidate [--for <funding-timeout|undercollateralization|courtesy-timeout|redemption-timeout>]
+        Attempts to liquidate the deposit, reporting back the status of
+        the liquidation . By default, looks for any available reason to
+        liquidate. When the flow completes, outputs the deposit as a
+        single tab-delimited line with the deposit address, current
+        deposit state, deposit lot size in satoshis, and the liquidation
+        status (\`liquidated\`, \`in-auction\`, or \`failed\`).
+
+        --for <funding-timeout|undercollateralization|courtesy-timeout|redemption-timeout>
+            If specified, only triggers liquidation for the specified
+            reason. If the reason does not apply, reports \`not-applicable\`
+            status.
+
+    withdraw [--dry-run]
+        Attempts to withdraw the current account's allowance from a tBTC
+        deposit. Only the amount allowed for the current account is
+        withdrawn. Outputs the withdrawn amount in wei once withdrawal
+        is complete.
+
+        --dry-run
+            Outputs the amount that would be withdrawn in wei, but does
+            not broadcast the transaction to withdraw it.`
+]
+
+/**
+ * @param {Web3} web3 An initialized Web3 instance TBTC is configured to use.
+ * @param {Array<string>} args
+ * @return {CommandAction | null}
+ */
+export function parseDepositCommand(web3, args) {
+  if (args.length > 0) {
+    const [command, ...commandArgs] = args
+    switch (command) {
+      case "new":
+        {
+          const {
+            found: { noMint },
+            remaining: [lotSizeString]
+          } = findAndConsumeArgsExistence(commandArgs, "--no-mint")
+
+          const lotSizeSatoshis = lotSizeString && bnOrNull(web3, lotSizeString)
+          if (lotSizeSatoshis) {
+            return async tbtc => {
+              return createDeposit(tbtc, lotSizeSatoshis, !noMint)
+            }
+          } else {
+            console.error(
+              "No lot size specified. Use lot-sizes to find available lot sizes."
+            )
+          }
+        }
+        break
+      case "list": {
+        const {
+          found: { vendingMachine: listVendingMachine },
+          remaining: postVendingMachine
+        } = findAndConsumeArgsExistence(commandArgs, "--vending-machine")
+        const {
+          found: { address },
+          remaining: postAddress
+        } = findAndConsumeArgsValues(postVendingMachine, "--address")
+
+        if (postAddress.length == 0) {
+          if (address !== null && listVendingMachine) {
+            console.error(
+              "Vending machine and address flag cannot be specified together."
+            )
+            break
+          }
+          if (address !== null && !web3.utils.isAddress(address)) {
+            console.error(`Address ${address} is not a valid Ethereum address.`)
+            break
+          }
+
+          const explicitAddress = address
+          return async tbtc => {
+            const address = listVendingMachine
+              ? tbtc.depositFactory.vendingMachine().options.address
+              : explicitAddress !== null
+              ? explicitAddress
+              : web3.defaultAccount
+
+            return listDeposits(tbtc, address)
+          }
+        }
+      }
+      default:
+        const depositAddress = command
+        const [subcommand, ...subcommandArgs] = commandArgs
+        if (!web3.utils.isAddress(depositAddress)) {
+          console.error(
+            `Deposit address ${depositAddress} is not a valid Ethereum address.`
+          )
+          break
+        }
+        if (typeof subcommand == "undefined") {
+          return async tbtc =>
+            standardDepositOutput(
+              tbtc,
+              await tbtc.Deposit.withAddress(depositAddress)
+            )
+        } else if (typeof commandParsers[subcommand] === "undefined") {
+          console.error(
+            `Invalid command after deposit address; command can be one of:\n` +
+              `    ${Object.keys(commandParsers).join(", ")}`
+          )
+          break
+        }
+
+        return commandParsers[subcommand](depositAddress, subcommandArgs)
+    }
+  }
+
+  // If we're here, no command matched.
+  return null
+}
+
+/** @enum {{ states: DepositStates[], method: string }} */
+const LIQUIDATION_HANDLERS = {
+  "setup-timeout": {
+    states: [DepositStates.AWAITING_SIGNER_SETUP],
+    method: "notifySignerSetupFailed"
+  },
+  "funding-timeout": {
+    states: [DepositStates.AWAITING_BTC_FUNDING_PROOF],
+    method: "notifyFundingTimedOut"
+  },
+  undercollateralization: {
+    states: [DepositStates.ACTIVE, DepositStates.COURTESY_CALL],
+    method: "notifyUndercollateralizedLiquidation"
+  },
+  "courtesy-timeout": {
+    states: [DepositStates.COURTESY_CALL],
+    method: "notifyCourtesyCallExpired"
+  },
+  "redemption-signature-timeout": {
+    states: [DepositStates.AWAITING_WITHDRAWAL_PROOF],
+    method: "notifyRedemptionSignatureTimedOut"
+  },
+  "redemption-proof-timeout": {
+    states: [DepositStates.AWAITING_WITHDRAWAL_SIGNATURE],
+    method: "notifyRedemptionProofTimedOut"
+  }
+}
+
+/** @typedef {keyof typeof LIQUIDATION_HANDLERS} AVAILABLE_LIQUIDATION_REASONS */
+
+/**
+ * @type {Object.<string,(depositAddress: string, args: string[])=>CommandAction | null>}
+ */
+const commandParsers = {
+  redeem: (depositAddress, args) => {
+    const [redemptionBitcoinAddress, ...remaining] = args
+
+    if (!redemptionBitcoinAddress) {
+      console.log("Bitcoin address required for redemption.")
+      return null
+    } else if (remaining.length > 0) {
+      return null
+    } else {
+      return async tbtc => {
+        const deposit = await tbtc.Deposit.withAddress(depositAddress)
+        return redeemDeposit(tbtc, deposit, "")
+      }
+    }
+  },
+  withdraw: (depositAddress, args) => {
+    const { existence: onlyCall, remaining } = findAndConsumeArgExistence(
+      args,
+      "--dry-run"
+    )
+
+    if (remaining.length > 0) {
+      return null
+    } else {
+      return async tbtc => withdrawFromDeposit(tbtc, depositAddress, onlyCall)
+    }
+  },
+  resume: (depositAddress, args) => {
+    const {
+      found: { noMint, funding: onlyFunding, redemption: onlyRedemption },
+      remaining
+    } = findAndConsumeArgsExistence(
+      args,
+      "--no-mint",
+      "--funding",
+      "--redemption"
+    )
+
+    if (onlyFunding && onlyRedemption) {
+      console.error(
+        "--funding and --redemption cannot both be specified. Specify neither\n" +
+          "if you want to resume all flows no matter the deposit state."
+      )
+      return null
+    } else if (onlyRedemption && noMint) {
+      console.error(
+        "--redemption specified with --no-mint, but redemption cannot mint."
+      )
+      return null
+    } else if (remaining.length > 0) {
+      return null
+    } else {
+      return async tbtc =>
+        resumeDeposit(
+          tbtc,
+          depositAddress,
+          onlyFunding,
+          onlyRedemption,
+          !noMint
+        )
+    }
+  },
+  "courtesy-call": (depositAddress, args) => {
+    if (args.length > 0) {
+      return null
+    } else {
+      return async tbtc => {
+        const deposit = await tbtc.Deposit.withAddress(depositAddress)
+        await deposit.notifyCourtesyCall()
+        return standardDepositOutput(tbtc, deposit)
+      }
+    }
+  },
+  liquidate: (depositAddress, args) => {
+    const {
+      found: { for: liquidationReason },
+      remaining
+    } = findAndConsumeArgsValues(args, "for")
+
+    if (liquidationReason && liquidationReason in LIQUIDATION_HANDLERS) {
+      console.error(
+        `Invalid liquidation reason; only one of these is allowed:\n` +
+          `    ${Object.keys(LIQUIDATION_HANDLERS).join(", ")}`
+      )
+      return null
+    } else if (remaining.length > 0) {
+      return null
+    } else {
+      return async tbtc =>
+        liquidateDeposit(
+          tbtc,
+          depositAddress,
+          /** @type {AVAILABLE_LIQUIDATION_REASONS} */ (liquidationReason) ||
+            undefined
+        )
+    }
+  }
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {string | null} ownerAddress
+ */
+async function listDeposits(tbtc, ownerAddress) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      // Find tokens that were owned by the owner address at any point.
+      const ownedDepositTokens = (
+        await EthereumHelpers.getExistingEvents(
+          tbtc.Deposit.depositToken(),
+          "Transfer",
+          { to: ownerAddress || "" }
+        )
+      ).map(
+        (/** @type {any} */ _) => /** @type {string} */ (_.returnValues.tokenId)
+      )
+
+      // Filter out any that are no longer owned by the owner address.
+      const stillOwned = (
+        await Promise.all(
+          /** @type Promise<[string, boolean]>[] */
+          ownedDepositTokens.map(tokenId =>
+            tbtc.Deposit.depositToken()
+              .methods.ownerOf(tokenId)
+              .call()
+              .then((/** @type {string} */ _) => [tokenId, _ == ownerAddress])
+          )
+        )
+      )
+        .filter(([, ownedByVm]) => ownedByVm)
+        .map(([tokenId]) => tokenId)
+
+      const deposits = await Promise.all(
+        stillOwned.map(_ => tbtc.Deposit.withTdtId(_))
+      )
+
+      const depositInfo = await Promise.all(
+        deposits.map(async _ => {
+          return standardDepositOutput(tbtc, _)
+        })
+      )
+
+      resolve(depositInfo.join("\n"))
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {BN} satoshiLotSize
+ * @param {boolean} mintOnActive
+ * @return {Promise<string>}
+ */
+async function createDeposit(tbtc, satoshiLotSize, mintOnActive) {
+  const deposit = await tbtc.Deposit.withSatoshiLotSize(satoshiLotSize)
+
+  return runDeposit(tbtc, deposit, mintOnActive)
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {string} depositAddress
+ * @param {boolean} onlyFunding Only resume a funding flow for this deposit.
+ * @param {boolean} onlyRedemption Only resume a redemption flow for this deposit.
+ * @param {boolean} mintOnActive If in a funding flow, proceed to minting once
+ *        deposit is qualified.
+ * @return {Promise<string>}
+ */
+async function resumeDeposit(
+  tbtc,
+  depositAddress,
+  onlyFunding,
+  onlyRedemption,
+  mintOnActive
+) {
+  const deposit = await tbtc.Deposit.withAddress(depositAddress)
+  const depositState = await deposit.getCurrentState()
+
+  if (
+    (onlyFunding && depositState >= tbtc.Deposit.State.ACTIVE) ||
+    (onlyRedemption && depositState < tbtc.Deposit.State.ACTIVE)
+  ) {
+    throw new Error("Nothing to resume for deposit.")
+  }
+
+  const existingRedemptionDetails = await deposit.getLatestRedemptionDetails()
+  if (existingRedemptionDetails) {
+    return redeemDeposit(tbtc, deposit, existingRedemptionDetails)
+  } else {
+    return runDeposit(tbtc, deposit, mintOnActive)
+  }
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {Deposit} deposit
+ * @param {Object} [alreadyResolved] When specified, carries information about
+ *        already-resolved properties of the deposit.
+ * @param {number} [alreadyResolved.state] The already-resolved state of the
+ *        deposit.
+ * @param {BN} [alreadyResolved.lotSizeSatoshis] The already-resolved lot size
+ *        of the deposit, in satoshis.
+ * @param {BN} [alreadyResolved.collateralization] The already-resolved
+ *        collateralization percentage of the deposit, as an integer (with 100
+ *        being 100%).
+ */
+async function standardDepositOutput(tbtc, deposit, alreadyResolved) {
+  const resolved = alreadyResolved || {
+    state: undefined,
+    lotSizeSatoshis: undefined,
+    collateralization: undefined
+  }
+
+  const depositState = resolved.state || (await deposit.getCurrentState())
+  const stateName = tbtc.Deposit.stateById(depositState)
+  const lotSize =
+    resolved.lotSizeSatoshis || (await deposit.getLotSizeSatoshis())
+  const collateralization =
+    resolved.collateralization ||
+    (await deposit.getCollateralizationPercentage())
+
+  return [
+    deposit.address,
+    stateName,
+    lotSize.toString().padEnd(8),
+    collateralization
+  ].join("\t")
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {Deposit} deposit
+ * @param {RedemptionDetails | string} redemptionInfo When RedemptionDetails,
+ *        the details on the existing redemption that should be resumed. When a
+ *        string, the Bitcoin address the receiver would like to receive
+ *        redeemed BTC at.
+ * @return {Promise<string>}
+ */
+async function redeemDeposit(tbtc, deposit, redemptionInfo) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      let redemption
+      if (typeof redemptionInfo == "string") {
+        redemption = await deposit.requestRedemption(redemptionInfo)
+      } else {
+        redemption = new Redemption(deposit, redemptionInfo)
+      }
+      redemption.autoSubmit()
+
+      redemption.onWithdrawn(transactionID => {
+        resolve(standardDepositOutput(tbtc, deposit) + "\t" + transactionID)
+      })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {Deposit} deposit
+ * @param {boolean} mintOnActive
+ * @return {Promise<string>}
+ */
+async function runDeposit(tbtc, deposit, mintOnActive) {
+  deposit.autoSubmit()
+
+  return new Promise(async (resolve, reject) => {
+    deposit.onBitcoinAddressAvailable(async address => {
+      // TODO Create a flow where output can be easily used to automate.
+      try {
+        const lotSize = await deposit.getLotSizeSatoshis()
+        console.log(
+          "\tGot deposit address:",
+          address,
+          "; fund with:",
+          lotSize.toString(),
+          "satoshis please."
+        )
+        console.log("Now monitoring for deposit transaction...")
+      } catch (err) {
+        reject(err)
+      }
+    })
+
+    deposit.onActive(async () => {
+      try {
+        if (mintOnActive) {
+          // TODO Create a flow where output can be easily used to automate.
+          console.log("Deposit is active, minting...")
+          const mintedTbtc = await deposit.mintTBTC()
+
+          resolve(
+            standardDepositOutput(tbtc, deposit) + "\t" + mintedTbtc.toString()
+          )
+        } else {
+          resolve(standardDepositOutput(tbtc, deposit))
+        }
+      } catch (err) {
+        reject(err)
+      }
+    })
+  })
+}
+
+/**
+ * Executes a command to withdraw the ETH available to the current account from
+ * the given deposit. If `onlyCall` is specified and passed as `true`, only
+ * checks the available amount without sending a transaction to withdraw it.
+ *
+ * @param {TBTCInstance} tbtc
+ * @param {string} depositAddress The address of
+ * @param {boolean} [onlyCall]
+ */
+async function withdrawFromDeposit(tbtc, depositAddress, onlyCall) {
+  const deposit = await tbtc.Deposit.withAddress(depositAddress)
+  const method = deposit.contract.methods.withdrawFunds()
+
+  if (onlyCall) {
+    return await method.call()
+  } else {
+    return await EthereumHelpers.sendSafely(method, {
+      from: tbtc.config.web3.eth.defaultAccount || undefined
+    })
+  }
+}
+
+/**
+ * @param {TBTCInstance} tbtc
+ * @param {string} depositAddress
+ * @param {AVAILABLE_LIQUIDATION_REASONS} [liquidationReason]
+ */
+async function liquidateDeposit(tbtc, depositAddress, liquidationReason) {
+  const deposit = await tbtc.Deposit.withAddress(depositAddress)
+  const depositState = await deposit.getCurrentState()
+
+  if (liquidationReason) {
+    const { states, method } = LIQUIDATION_HANDLERS[liquidationReason]
+    if (states.includes(depositState)) {
+      await EthereumHelpers.sendSafely(deposit.contract.methods[method](), {
+        from: tbtc.config.web3.eth.defaultAccount || undefined
+      })
+      return standardDepositOutput(tbtc, deposit)
+    } else {
+      throw new Error(
+        `Deposit is not in a state that allows ${liquidationReason} liquidation.`
+      )
+    }
+  } else {
+    const depositStateName = tbtc.Deposit.stateById(depositState)
+    const matchingHandler = Object.values(
+      LIQUIDATION_HANDLERS
+    ).find(({ states }) => states.includes(depositState))
+
+    if (matchingHandler) {
+      const { method } = matchingHandler
+      console.debug(
+        `Attempting to liquidate deposit based on state ${depositStateName} using ${method}.`
+      )
+
+      await EthereumHelpers.sendSafely(deposit.contract.methods[method](), {
+        from: tbtc.config.web3.eth.defaultAccount || undefined
+      })
+      return standardDepositOutput(tbtc, deposit)
+    } else {
+      throw new Error(
+        `Could not find a possible liquidation strategy for deposit state ${depositStateName}`
+      )
+    }
+  }
+}
+
+/**
+ * Converts the given string to a `BN` instance, or returns `null` if that
+ * fails.
+ *
+ * @param {Web3} web3 The web3 instance to use for BN conversion.
+ * @param {string} str The string to potentially convert to `BN`.
+ * @return {BN?} The `BN` instance for the string, or `null` if the string could
+ *         not be converted.
+ */
+function bnOrNull(web3, str) {
+  try {
+    return web3.utils.toBN(str)
+  } catch (_) {
+    return null
+  }
+}

--- a/bin/config.json
+++ b/bin/config.json
@@ -1,0 +1,26 @@
+{
+    "1": {
+      "bitcoinNetwork": "main",
+        "electrum": {
+          "server": "electrumx-server.tbtc.network",
+          "port": 8443,
+          "protocol": "wss"
+        }
+    },
+    "3": {
+      "bitcoinNetwork": "testnet",
+      "electrum": {
+          "server": "electrumx-server.test.tbtc.network",
+          "port": 8443,
+          "protocol": "wss"
+      }
+    },
+    "1101": {
+      "bitcoinNetwork": "regtest",
+      "electrum": {
+          "server": "127.0.0.1",
+          "port": 50003,
+          "protocol": "ws"
+      }
+    }
+  }

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -1,0 +1,191 @@
+// Tools for consuming arguments functionally.
+// In particular, these helpers are designed to consume from an argument list
+// and return copies of that argument list with consumed arguments removed.
+
+/**
+ * Finds an argument named `argName` in the list of arguments and returns an
+ * object with the index of the argument in the original argument list, and the
+ * remaining arguments without the matching argument.
+ *
+ * @param {string[]} args The list of all command-line arguments.
+ * @param {string} argName The name of an argument to look for.
+ * @return {{index: number, remaining: string[]}} An object with the index of
+ *         the matching argument in the original args list, and a list of
+ *         remaining arguments with the matching one removed. The index will be
+ *         -1 if the argument was not found, and the `remaining` list will have
+ *         the same elements as `args` in that case.
+ */
+export function findAndConsumeArg(args, argName) {
+  const index = args.indexOf(argName)
+  return {
+    index,
+    remaining:
+      index < 0
+        ? args.slice(0)
+        : args.slice(0, index).concat(args.slice(index + 1))
+  }
+}
+
+/**
+ * Finds an argument named `argName` in the list of arguments and returns an
+ * object with a boolean `existence` indicating whether the argument was found,
+ * and `remaining` set to the remaining arguments without the matching argument.
+ *
+ * @param {string[]} args The list of all command-line arguments.
+ * @param {string} argName The name of an argument to look for.
+ * @return {{existence: boolean, remaining: string[]}} An object with a boolean
+ *         `existence` set to `true` if the argument was found or `false`
+ *         otherwise , and a list of remaining arguments with the matching one
+ *         removed. The `remaining` list will have the same elements as `args`
+ *         if the argument was not found.
+ */
+export function findAndConsumeArgExistence(args, argName) {
+  const { index, remaining } = findAndConsumeArg(args, argName)
+  return { existence: index != -1, remaining }
+}
+
+/** @typedef {{ [x: string]: boolean }} FoundArgsExistence */
+/** @typedef {{ [x: string]: string|null }} FoundArgsValues */
+
+/**
+ * Finds the set of argument names in `argsToCheck`, accumulating a map of
+ * argument names to booleans indicating if they were found in the list of
+ * arguments or not, and returns an object with `found` set to that map and
+ * the remaining arguments without any matching arguments.
+ *
+ * Note that arguments in the `found` list have leading `-` characters stripped
+ * and turn mid-word `-` into camel case, so e.g. "--debug" turns into "debug",
+ * "-v" turns into "v", and "--test-system" turns into "testSystem" in the
+ * `found` map.
+ *
+ * Example usage:
+ *
+ *     const args = process.argv.slice(1) // drop command name
+ *     const {
+ *         found: { debug, verbose, version },
+ *         remaining: nonBooleanArgs
+ *     } = findAndConsumeArgsExistence(args, "--debug", "--verbose", "--version")
+ *
+ *     // debug, verbose, version are true if --debug, --verbose, or --version
+ *     // were passed; nonBooleanArgs only contains any parameters that were NOT
+ *     // --debug, --verbose, or --version.
+ *
+ * @param {string[]} args The list of all command-line arguments.
+ * @param {string[]} argsToCheck The names of arguments to look for.
+ * @return {{found: FoundArgsExistence, remaining: string[]}} An object with
+ *         two properties: `found` maps argument names from `argsToCheck` to
+ *         a boolean indicating whether that argument name was found;
+ *         `remaining` has a list of remaining arguments with any matches from
+ *         `argsToCheck` removed. The `remaining` list will have the same
+ *         elements as `args` if none of the `argsToCheck` were found.
+ */
+export function findAndConsumeArgsExistence(args, ...argsToCheck) {
+  return argsToCheck.reduce(
+    ({ found, remaining }, argToCheck) => {
+      const {
+        existence,
+        remaining: postCheckArgs
+      } = findAndConsumeArgExistence(remaining, argToCheck)
+      return {
+        found: Object.assign(found, { [camelCase(argToCheck)]: existence }),
+        remaining: postCheckArgs
+      }
+    },
+    { found: {}, remaining: args }
+  )
+}
+
+/**
+ * Finds an argument named `argName` in the list of arguments and returns an
+ * object with `value` set to the argument after it, and `remaining` set to the
+ * remaining arguments without the matching argument and its immediately
+ * subsequent value. This is designed to consume a flag like `--address magic`
+ * and read the value `magic`.
+ *
+ * @param {string[]} args The list of all command-line arguments.
+ * @param {string} argName The name of an argument to look for.
+ * @return {{value: string?, remaining: string[]}} An object with a `value`
+ *         property set to the argument after the matching argument name (if
+ *         found) if the argument was found or `null` otherwise, and a list of
+ *         remaining arguments with the matching one and its value removed. The
+ *         `remaining` list will have the same elements as `args` if the
+ *         argument was not found.
+ */
+export function findAndConsumeArgValue(args, argName) {
+  const { index, remaining } = findAndConsumeArg(args, argName)
+  const value = remaining[index]
+
+  if (index == -1) {
+    return { value: null, remaining }
+  } else {
+    return {
+      value: value,
+      remaining: remaining.slice(0, index).concat(args.slice(index + 1))
+    }
+  }
+}
+
+/**
+ * Finds the set of argument names in `argsToCheck`, accumulating a map of
+ * argument names to values read as the next element in the args list arguments
+ * or not, and returns an object with `found` set to that map and
+ * the remaining arguments without any matching arguments.
+ *
+ * Note that arguments in the `found` list have leading `-` characters stripped
+ * and turn mid-word `-` into camel case, so e.g. "--debug" turns into "debug",
+ * "-v" turns into "v", and "--test-system" turns into "testSystem" in the
+ * `found` map. Note also that arguments that were not found have their values
+ * set to `null`.
+ *
+ * Example usage:
+ *
+ *     const args = process.argv.slice(1) // drop command name
+ *     const {
+ *         found: { address, account, rpc },
+ *         remaining: otherArgs
+ *     } = findAndConsumeArgsExistence(args, "--address", "--account", "--rpc")
+ *
+ *     // For `--address 0x1234 --account boom`, `address` will be set to
+ *     // `0x1234`, `account` will be set to `boom`, and `rpc` will be set to
+ *     // `null`; nonBooleanArgs only contains any parameters that were NOT
+ *     // --address, --account, or --rpc.
+ *
+ * @param {string[]} args The list of all command-line arguments.
+ * @param {string[]} argsToCheck The names of arguments to look for.
+ * @return {{found: FoundArgsValues, remaining: string[]}} An object with
+ *         two properties: `found` maps argument names from `argsToCheck` to
+ *         values found as the next item in the args list; `remaining` has a list of
+ *         remaining arguments with any matches from `argsToCheck` removed. The
+ *         `remaining` list will have the same elements as `args` if none of the
+ *         `argsToCheck` were found.
+ */
+export function findAndConsumeArgsValues(args, ...argsToCheck) {
+  return argsToCheck.reduce(
+    ({ found, remaining }, argToCheck) => {
+      const { value, remaining: postCheckArgs } = findAndConsumeArgValue(
+        remaining,
+        argToCheck
+      )
+      return {
+        found: Object.assign(found, { [camelCase(argToCheck)]: value }),
+        remaining: postCheckArgs
+      }
+    },
+    { found: {}, remaining: args }
+  )
+}
+
+/**
+ * Takes an argument name and camel-cases it by dropping all leading `-` and
+ * turning any interstitial `-<letter>` into an uppercase of the letter.
+ *
+ * @param {string} argName The name of a command-line argument, typically as a
+ *        --dashed-name.
+ * @return {string} The argument name, which is typically a --dashed-name, as a
+ *         camel-cased version (e.g. "dashedName").
+ */
+function camelCase(argName) {
+  return argName
+    .replace(/^-*/, "")
+    .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+}

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -120,7 +120,7 @@ export function findAndConsumeArgValue(args, argName) {
   } else {
     return {
       value: value,
-      remaining: remaining.slice(0, index).concat(args.slice(index + 1))
+      remaining: remaining.slice(0, index).concat(args.slice(index + 2))
     }
   }
 }

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -2,11 +2,15 @@
 import Subproviders from "@0x/subproviders"
 import Web3 from "web3"
 import ProviderEngine from "web3-provider-engine"
+import WebsocketSubprovider from "web3-provider-engine/subproviders/websocket.js"
 import TBTC from "../index.js"
-/** @typedef {import('../src/TBTC.js').ElectrumConfig} ElectrumConfig */
+import { depositCommandHelp, parseDepositCommand } from "./commands/deposit.js"
+import {
+  findAndConsumeArgsExistence,
+  findAndConsumeArgsValues
+} from "./helpers.js"
+import AvailableConfigs from "./config.json"
 /** @typedef {import('../src/TBTC.js').TBTC} TBTCInstance */
-/** @typedef {import('../src/Deposit.js').default} Deposit */
-/** @typedef {import('bn.js')} BN */
 
 /**
  * An action that runs a set command on a given TBTC instance and returns a
@@ -17,41 +21,41 @@ import TBTC from "../index.js"
  * @return {Promise<string>} The output of the command.
  */
 
-/** @type {{ [name: string]: ElectrumConfig }} */
-const electrumConfigs = {
-  testnet: {
-    server: "electrumx-server.test.tbtc.network",
-    port: 8443,
-    protocol: "wss"
-  },
-  testnetTCP: {
-    server: "electrumx-server.test.tbtc.network",
-    port: 50002,
-    protocol: "ssl"
-  },
-  mainnet: {
-    server: "electrumx-server.tbtc.network",
-    port: 8443,
-    protocol: "wss"
-  },
-  mainnetTCP: {
-    server: "electrumx-server.tbtc.network",
-    port: 50002,
-    protocol: "ssl"
-  }
+// --------------------------------- ARGS --------------------------------------
+let args = process.argv.slice(2)
+if (process.argv[0].includes("tbtc.js")) {
+  args = process.argv.slice(1) // invoked directly, no node
 }
 
+// No debugging unless explicitly enabled.
+const {
+  found: { debug },
+  remaining: flagArgs
+} = findAndConsumeArgsExistence(args, "--debug")
+if (!debug) {
+  console.debug = () => {}
+}
+
+const {
+  found: { mnemonic, account, rpc },
+  remaining: commandArgs
+} = findAndConsumeArgsValues(flagArgs, "--mnemonic", "--account", "--rpc")
 const engine = new ProviderEngine({ pollingInterval: 1000 })
+
 engine.addProvider(
   // For address 0x420ae5d973e58bc39822d9457bf8a02f127ed473.
   new Subproviders.PrivateKeyWalletSubprovider(
-    "b6252e08d7a11ab15a4181774fdd58689b9892fe9fb07ab4f026df9791966990"
+    mnemonic ||
+      "b6252e08d7a11ab15a4181774fdd58689b9892fe9fb07ab4f026df9791966990"
   )
 )
 engine.addProvider(
-  new Subproviders.RPCSubprovider(
-    "https://:e18ef5ef295944928dd87411bc678f19@ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
-  )
+  new WebsocketSubprovider({
+    rpcUrl:
+      rpc || "wss://ropsten.infura.io/ws/v3/414a548bc7434bbfb7a135b694b15aa4",
+    debug,
+    origin: undefined
+  })
 )
 
 // -------------------------------- SETUP --------------------------------------
@@ -60,48 +64,39 @@ engine.addProvider(
 const web3 = new Web3(engine)
 engine.start()
 
-// --------------------------------- ARGS --------------------------------------
-let args = process.argv.slice(2)
-if (process.argv[0].includes("tbtc.js")) {
-  args = process.argv.slice(1) // invoked directly, no node
-}
-
 /** @type {CommandAction | null} */
 let action = null
 
-switch (args[0]) {
+switch (commandArgs[0]) {
   case "deposit":
-    {
-      let mint = true
-      if (args.length == 3 && args[2] == "--no-mint") {
-        mint = false
-        args.pop() // drop --no-mint
-      }
-      if (args.length == 2 && bnOrNull(args[1])) {
-        action = async tbtc => {
-          return await createDeposit(tbtc, web3.utils.toBN(args[1]), mint)
-        }
-      }
-    }
+    action = parseDepositCommand(web3, commandArgs.slice(1))
     break
-  case "resume":
-    {
-      let mint = true
-      if (args.length == 3 && args[2] == "--no-mint") {
-        mint = false
-        args.pop() // drop --no-mint
-      }
-      if (args.length == 2 && web3.utils.isAddress(args[1])) {
-        action = async tbtc => {
-          return await resumeDeposit(tbtc, args[1], mint)
-        }
-      }
-    }
-    break
-  case "redeem":
-    if (args.length == 3 && web3.utils.isAddress(args[1])) {
+  case "lot-sizes":
+    if (args.length == 1) {
       action = async tbtc => {
-        return await redeemDeposit(tbtc, args[1], args[2])
+        return (await tbtc.Deposit.availableSatoshiLotSizes())
+          .map(_ => _.toString())
+          .join("\n")
+      }
+    }
+    break
+  case "supply":
+    if (args.length == 1) {
+      action = async tbtc => {
+        return await tbtc.depositFactory
+          .vendingMachine()
+          .methods.getMintedSupply()
+          .call()
+      }
+    }
+    break
+  case "supply-cap":
+    if (args.length == 1) {
+      action = async tbtc => {
+        return await tbtc.depositFactory
+          .vendingMachine()
+          .methods.getMaxSupply()
+          .call()
       }
     }
     break
@@ -109,25 +104,48 @@ switch (args[0]) {
 
 if (action === null) {
   console.log(`
-Unknown command ${args[0]} or bad parameters. Supported commands:
-    deposit <lot-size-satoshis> [--no-mint]
-        Initiates a deposit funding flow. Takes the lot size in satoshis.
-        Will prompt with a Bitcoin address when funding needs to be
-        submitted.
+Unknown command ${args[0]} or bad parameters.
 
-        --no-mint
-            specifies not to mint TBTC once the deposit is qualified.
+Supported flags:
+    --debug
+        Enable debug output.
 
-    resume <deposit-address> [--no-mint]
-        Resumes a deposit funding flow that did not complete. An existing
-        funding transaction can exist, but this can also be run before the
-        funding transaction is submitted.
+    --rpc <rpc-url>
+        Set RPC URL to the specified value.
 
-        --no-mint
-            specifies not to mint TBTC once the deposit is qualified.
+    --mnemonic <mnemonic>
+        Use the specified for the operating account. Also supports private key
+        strings, since the underlying provider accepts these.
 
-    redeem <deposit-address>
-        Attempts to redeem a tBTC deposit.
+    --account <account>
+        Use the specified account for all transactions. If --mnemonic is
+        specified, it must be able to sign for this account in order for
+        mutating transactions to be sent to the Ethereum chain. If this is
+        left off, the first account for the private key is used.
+
+Supported commands:
+${depositCommandHelp
+  .map(
+    _ =>
+      "    deposit " +
+      _.split("\n")[0] +
+      "\n" +
+      _.split("\n")
+        .slice(1)
+        .map(_ => "    " + _)
+        .join("\n")
+  )
+  .join("\n\n")}
+
+    lot-sizes
+        Returns a list of the currently available lot sizes, one per line.
+
+    supply
+        Returns the current supply as a decimal amount in TBTC. 18 decimals of
+        precision, but with a decimal point.
+
+    supply-cap
+        Returns the current supply cap as a decimal amount in TBTC.
     `)
 
   process.exit(1)
@@ -138,12 +156,15 @@ Unknown command ${args[0]} or bad parameters. Supported commands:
  * @return {Promise<string>}
  */
 async function runAction(action) {
-  web3.eth.defaultAccount = (await web3.eth.getAccounts())[0]
+  web3.eth.defaultAccount = account || (await web3.eth.getAccounts())[0]
+  const chainId = await web3.eth.getChainId()
+  // @ts-ignore TypeScript mad.
+  const config = AvailableConfigs[chainId.toString()]
 
   const tbtc = await TBTC.withConfig({
     web3: web3,
-    bitcoinNetwork: "testnet",
-    electrum: electrumConfigs.testnet
+    bitcoinNetwork: config.bitcoinNetwork,
+    electrum: config.electrum
   })
 
   return action(tbtc)
@@ -151,117 +172,12 @@ async function runAction(action) {
 
 runAction(/** @type {CommandAction} */ (action))
   .then(result => {
-    console.log("Action completed with final result:", result)
+    console.log(result)
 
     process.exit(0)
   })
   .catch(error => {
-    console.error("Action errored out with error:", error)
+    console.error("ERROR ", error)
 
     process.exit(1)
   })
-
-/**
- * @param {TBTCInstance} tbtc
- * @param {BN} satoshiLotSize
- * @param {boolean} mintOnActive
- * @return {Promise<string>}
- */
-async function createDeposit(tbtc, satoshiLotSize, mintOnActive) {
-  const deposit = await tbtc.Deposit.withSatoshiLotSize(satoshiLotSize)
-
-  return runDeposit(deposit, mintOnActive)
-}
-
-/**
- * @param {TBTCInstance} tbtc
- * @param {string} depositAddress
- * @param {boolean} mintOnActive
- * @return {Promise<string>}
- */
-async function resumeDeposit(tbtc, depositAddress, mintOnActive) {
-  const deposit = await tbtc.Deposit.withAddress(depositAddress)
-
-  return runDeposit(deposit, mintOnActive)
-}
-
-/**
- * @param {TBTCInstance} tbtc
- * @param {string} depositAddress
- * @param {string} redeemerAddress
- * @return {Promise<string>}
- */
-async function redeemDeposit(tbtc, depositAddress, redeemerAddress) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const deposit = await tbtc.Deposit.withAddress(depositAddress)
-      const redemption = await deposit.requestRedemption(redeemerAddress)
-      redemption.autoSubmit()
-
-      redemption.onWithdrawn(transactionID => {
-        console.log()
-
-        resolve(
-          `Redeemed deposit ${deposit.address} with Bitcoin transaction ` +
-            `${transactionID}.`
-        )
-      })
-    } catch (err) {
-      reject(err)
-    }
-  })
-}
-
-/**
- * @param {Deposit} deposit
- * @param {boolean} mintOnActive
- * @return {Promise<string>}
- */
-async function runDeposit(deposit, mintOnActive) {
-  deposit.autoSubmit()
-
-  return new Promise(async (resolve, reject) => {
-    deposit.onBitcoinAddressAvailable(async address => {
-      try {
-        const lotSize = await deposit.getLotSizeSatoshis()
-        console.log(
-          "\tGot deposit address:",
-          address,
-          "; fund with:",
-          lotSize.toString(),
-          "satoshis please."
-        )
-        console.log("Now monitoring for deposit transaction...")
-      } catch (err) {
-        reject(err)
-      }
-    })
-
-    deposit.onActive(async () => {
-      try {
-        if (mintOnActive) {
-          console.log("Deposit is active, minting...")
-          const tbtc = await deposit.mintTBTC()
-
-          resolve(tbtc.toString())
-        } else {
-          resolve("Deposit is active. Minting disabled by parameter.")
-        }
-      } catch (err) {
-        reject(err)
-      }
-    })
-  })
-}
-
-/**
- * @param {string} str
- * @return {BN?}
- */
-function bnOrNull(str) {
-  try {
-    return web3.utils.toBN(str)
-  } catch (_) {
-    return null
-  }
-}

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -72,7 +72,7 @@ switch (commandArgs[0]) {
     action = parseDepositCommand(web3, commandArgs.slice(1))
     break
   case "lot-sizes":
-    if (args.length == 1) {
+    if (commandArgs.length == 1) {
       action = async tbtc => {
         return (await tbtc.Deposit.availableSatoshiLotSizes())
           .map(_ => _.toString())
@@ -81,7 +81,7 @@ switch (commandArgs[0]) {
     }
     break
   case "supply":
-    if (args.length == 1) {
+    if (commandArgs.length == 1) {
       action = async tbtc => {
         return await tbtc.depositFactory
           .vendingMachine()
@@ -91,7 +91,7 @@ switch (commandArgs[0]) {
     }
     break
   case "supply-cap":
-    if (args.length == 1) {
+    if (commandArgs.length == 1) {
       action = async tbtc => {
         return await tbtc.depositFactory
           .vendingMachine()

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -104,7 +104,7 @@ switch (commandArgs[0]) {
 
 if (action === null) {
   console.log(`
-Unknown command ${args[0]} or bad parameters.
+Unknown command ${commandArgs[0]} or bad parameters.
 
 Supported flags:
     --debug

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -100,6 +100,21 @@ switch (commandArgs[0]) {
       }
     }
     break
+  case "balance":
+    if (commandArgs.length == 1) {
+      action = async tbtc => {
+        return await tbtc.Deposit.token()
+          .methods.balanceOf(tbtc.config.web3.eth.defaultAccount)
+          .call()
+      }
+    } else if (commandArgs.length == 2) {
+      action = async tbtc => {
+        return await tbtc.Deposit.token()
+          .methods.balanceOf(commandArgs[1])
+          .call()
+      }
+    }
+    break
 }
 
 if (action === null) {
@@ -146,6 +161,10 @@ ${depositCommandHelp
 
     supply-cap
         Returns the current supply cap as a decimal amount in TBTC.
+
+    balance [<address>]
+        Returns the balance of the current account in TBTC or, if the address is
+        specified, of the specified address.
     `)
 
   process.exit(1)

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -52,7 +52,7 @@ engine.addProvider(
 engine.addProvider(
   new WebsocketSubprovider({
     rpcUrl:
-      rpc || "wss://ropsten.infura.io/ws/v3/414a548bc7434bbfb7a135b694b15aa4",
+      rpc || "wss://mainnet.infura.io/ws/v3/414a548bc7434bbfb7a135b694b15aa4",
     debug,
     origin: undefined
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,41 +5,41 @@
   "requires": true,
   "dependencies": {
     "@0x/assert": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-3.0.9.tgz",
-      "integrity": "sha512-ywQuG8feXtIpRn/3tekPZeXLjKfDJPooA5QJEDxHDv1E5ZjSrKSK6B3wdkVW6NJvNPECw0eKjM50uF2784tbfA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-3.0.7.tgz",
+      "integrity": "sha512-HYdVvIgj/wVb20MVveazLQwICxZGelNuyu/U09ZSMzRy1NrDgrBiMjrU4WrcpW2GTPZjl+7R4U4/7h/C8I/egQ==",
       "dev": true,
       "requires": {
-        "@0x/json-schemas": "^5.1.0",
-        "@0x/typescript-typings": "^5.1.1",
-        "@0x/utils": "^5.5.1",
+        "@0x/json-schemas": "^5.0.7",
+        "@0x/typescript-typings": "^5.0.2",
+        "@0x/utils": "^5.4.1",
         "lodash": "^4.17.11",
         "valid-url": "^1.0.9"
       }
     },
     "@0x/json-schemas": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-5.1.0.tgz",
-      "integrity": "sha512-qDiCz94AR140puQ0MHT6XyDbmDrvWjw+Zyysmf4tD9PfM8sD+MOhF9dfvaYPNlS51M1CIlOTWZYqo5OUCIBEXQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-5.0.7.tgz",
+      "integrity": "sha512-/7gbLno+qQRNjLWRkulbPVOnRoP7uN5CnNP+VKydpKArBgU/E38rUVzSl/Y6FaPbhwC/Rs0d0BmP2Y5DMozjyA==",
       "dev": true,
       "requires": {
-        "@0x/typescript-typings": "^5.1.1",
+        "@0x/typescript-typings": "^5.0.2",
         "@types/node": "*",
         "jsonschema": "^1.2.0",
         "lodash.values": "^4.3.0"
       }
     },
     "@0x/subproviders": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@0x/subproviders/-/subproviders-6.1.1.tgz",
-      "integrity": "sha512-5rXmQbokPAlq6Am+O/C2QV6VlxKJGREncJ50ymLp0z8Bsyjt864Mgb1sB1ym19Qg6EJEhamQiJzVrrkN4ApbTQ==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@0x/subproviders/-/subproviders-6.0.8.tgz",
+      "integrity": "sha512-OEFZ6qdkHfAvkkcvXSLiCJd2V87NGiZvNcZZkNeupCK77mlDnO0k/IpCe3hr9bUu8PV8vOBvrQaE973vjyCfgQ==",
       "dev": true,
       "requires": {
-        "@0x/assert": "^3.0.9",
-        "@0x/types": "^3.2.0",
-        "@0x/typescript-typings": "^5.1.1",
-        "@0x/utils": "^5.5.1",
-        "@0x/web3-wrapper": "^7.2.0",
+        "@0x/assert": "^3.0.7",
+        "@0x/types": "^3.1.2",
+        "@0x/typescript-typings": "^5.0.2",
+        "@0x/utils": "^5.4.1",
+        "@0x/web3-wrapper": "^7.0.7",
         "@ledgerhq/hw-app-eth": "^4.3.0",
         "@ledgerhq/hw-transport-node-hid": "^4.3.0",
         "@ledgerhq/hw-transport-u2f": "4.24.0",
@@ -47,55 +47,164 @@
         "@types/web3-provider-engine": "^14.0.0",
         "bip39": "^2.5.0",
         "bn.js": "^4.11.8",
-        "ethereum-types": "^3.2.0",
+        "ethereum-types": "^3.1.0",
         "ethereumjs-tx": "^1.3.5",
         "ethereumjs-util": "^5.1.1",
-        "ganache-core": "^2.10.2",
+        "ganache-core": "^2.9.0-istanbul.0",
         "hdkey": "^0.7.1",
         "json-rpc-error": "2.0.0",
         "lodash": "^4.17.11",
         "semaphore-async-await": "^1.5.1",
         "web3-provider-engine": "14.0.6"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "hdkey": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
+          "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
+          "dev": true,
+          "requires": {
+            "coinstring": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "14.0.6",
+          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.0.6.tgz",
+          "integrity": "sha512-tr5cGSyxfSC/JqiUpBlJtfZpwQf1yAA8L/zy1C6fDFm0ntR974pobJ4v4676atpZne4Ze5VFy3kPPahHe9gQiQ==",
+          "dev": true,
+          "requires": {
+            "async": "^2.5.0",
+            "backoff": "^2.5.0",
+            "clone": "^2.0.0",
+            "cross-fetch": "^2.1.0",
+            "eth-block-tracker": "^3.0.0",
+            "eth-json-rpc-infura": "^3.1.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.1.5",
+            "ethereumjs-vm": "^2.3.4",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "readable-stream": "^2.2.9",
+            "request": "^2.67.0",
+            "semaphore": "^1.0.3",
+            "tape": "^4.4.0",
+            "ws": "^5.1.1",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "@0x/types": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@0x/types/-/types-3.2.0.tgz",
-      "integrity": "sha512-HcYXmz7gYtibJmZQjrQCnzV2FjRoo5b/Ul1QoTeQFAZ2M2ggt1wHspQ7vOkEAZEK/7TE4TKA4MlRwRLa4isL1Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@0x/types/-/types-3.1.2.tgz",
+      "integrity": "sha512-jweDayth9SSmvhx2Z5cARqQAdB9luzDm+GCzmpqQXYpdPPUzUMXQWjepGouLUgLEoBEq7Xm7DkY+qcTq3ekrSQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "bignumber.js": "~9.0.0",
-        "ethereum-types": "^3.2.0"
+        "ethereum-types": "^3.1.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        }
       }
     },
     "@0x/typescript-typings": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-5.1.1.tgz",
-      "integrity": "sha512-a8/uKPNStHORFQzI/DDEq4ixb4IricPogAJ3P17YnNYr/yF3HwXEu6+cFxs4qi1fr0zGoPe7D3XtqtR+dX/ajQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-5.0.2.tgz",
+      "integrity": "sha512-syOJE/cN8lg4Homh/TGZPiS493NBmKBFjlaeOpnrjjzGcCG2SqY4nbj+VjGrvhJdw9/KM/J1nWqsCV+KSDORhg==",
       "dev": true,
       "requires": {
         "@types/bn.js": "^4.11.0",
         "@types/react": "*",
         "bignumber.js": "~9.0.0",
-        "ethereum-types": "^3.2.0",
+        "ethereum-types": "^3.1.0",
         "popper.js": "1.14.3"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        }
       }
     },
     "@0x/utils": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-5.5.1.tgz",
-      "integrity": "sha512-UreVm7R/qEv1v4dVccb4Y6Oz13o8ko2vB10sdNrPAGbstqx3NfdEBkylNxD7I8Bkta/BIwHrLbtCN3jni8CSeg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-5.4.1.tgz",
+      "integrity": "sha512-zmolzXYt1FZlF3nGI9I1FaMdPp3kQAO/ZmtObFjN2KHG35dl+BBk/lSlWtmaqlVLaSLBQzLREKgjswKEcyT+xA==",
       "dev": true,
       "requires": {
-        "@0x/types": "^3.2.0",
-        "@0x/typescript-typings": "^5.1.1",
+        "@0x/types": "^3.1.2",
+        "@0x/typescript-typings": "^5.0.2",
         "@types/node": "*",
         "abortcontroller-polyfill": "^1.1.9",
         "bignumber.js": "~9.0.0",
         "chalk": "^2.3.0",
         "detect-node": "2.0.3",
-        "ethereum-types": "^3.2.0",
+        "ethereum-types": "^3.1.0",
         "ethereumjs-util": "^5.1.1",
         "ethers": "~4.0.4",
         "isomorphic-fetch": "2.2.1",
@@ -103,38 +212,357 @@
         "lodash": "^4.17.11"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        },
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.47",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+          "dev": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "js-sha3": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+              "dev": true
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "js-sha3": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
           "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
           "dev": true
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
         }
       }
     },
     "@0x/web3-wrapper": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-7.2.0.tgz",
-      "integrity": "sha512-5jRr5Xl/co5VZB2sCFiokuRwuPc2BENeSVuXll/+YNmytP5+C+7oDvVt6GrGP3j5921GIr4EhusZMbvOFw1oKQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-7.0.7.tgz",
+      "integrity": "sha512-4dqtJW14W2E/hFBL0mTBd6w7QYp3l+OxAsJwhbmB9xnhZj8DfLrQA2RC+cFZnUarhjUeXlUh2B1Zr6YXLv3lEQ==",
       "dev": true,
       "requires": {
-        "@0x/assert": "^3.0.9",
-        "@0x/json-schemas": "^5.1.0",
-        "@0x/typescript-typings": "^5.1.1",
-        "@0x/utils": "^5.5.1",
-        "ethereum-types": "^3.2.0",
+        "@0x/assert": "^3.0.7",
+        "@0x/json-schemas": "^5.0.7",
+        "@0x/typescript-typings": "^5.0.2",
+        "@0x/utils": "^5.4.1",
+        "ethereum-types": "^3.1.0",
         "ethereumjs-util": "^5.1.1",
         "ethers": "~4.0.4",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.47",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+          "dev": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+            }
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-bzz": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
+          "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
+          "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-requestmanager": "1.2.2"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
+          "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.2"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
+          "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
+          "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
+          "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-providers-http": "1.2.2",
+            "web3-providers-ipc": "1.2.2",
+            "web3-providers-ws": "1.2.2"
+          }
+        }
       }
     },
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.8.3"
       }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
@@ -143,20 +571,64 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
+      "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
       }
@@ -201,9 +673,9 @@
           "integrity": "sha512-qtpX8aFrUUlYfOMu7BxTvxqUa8CniE+tEBpVEjYUhVbFdVJjM4ouwJD++RtQkMAU2c5jE7xb12WnUnf5BlAgLQ=="
         },
         "@ledgerhq/hw-app-eth": {
-          "version": "5.23.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.23.0.tgz",
-          "integrity": "sha512-Oy7154MOTDGzWy501CmY8TDRS9Ahe/TDmhBvp38tGn/x/4gEm6FMXbms6arnI79244bBe033q6yqLmuWO/VSIw==",
+          "version": "5.24.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.24.0.tgz",
+          "integrity": "sha512-DWwvFIABiAI07u4gSHhdTsClUXNXRy19dXv8WcJ2mPAphkY1FFaQ7IFxW+Mq4OcRTWWoDQkZBWQzSI2HD6YLHg==",
           "requires": {
             "@ledgerhq/errors": "^5.23.0",
             "@ledgerhq/hw-transport": "^5.23.0",
@@ -226,10 +698,10 @@
           "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.23.0.tgz",
           "integrity": "sha512-88M8RkVHl44k6MAhfrYhx25opnJV24/2XpuTUVklID11f9rBdE+6RZ9OMs39dyX2sDv7TuzIPi5nTRoCqZMDYw=="
         },
-        "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ=="
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "cross-fetch": {
           "version": "3.0.4",
@@ -248,27 +720,42 @@
             "ms": "^2.1.1"
           }
         },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+            "elliptic": {
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
               "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "^2.2.3"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
               }
             }
           }
@@ -291,9 +778,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.30",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.30.tgz",
-              "integrity": "sha512-euU8QLX0ipj+5mOYa4ZqZoTv+53BY7yTg9I2ZIhDXgiI3M+0n4mdAt9TQCuvxVAgU179g8OsRLaBt0qEi0T6xA=="
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
             },
             "elliptic": {
               "version": "6.3.3",
@@ -306,36 +793,21 @@
                 "inherits": "^2.0.1"
               }
             },
-            "setimmediate": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+            "hash.js": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+              "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
+              }
             }
           }
         },
-        "eventemitter3": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        "events": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
         },
         "ms": {
           "version": "2.1.2",
@@ -347,88 +819,31 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
           "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        "rlp": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          }
         },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
         },
         "scrypt-js": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
           "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
         },
-        "swarm-js": {
-          "version": "0.1.39",
-          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
-          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
-          "requires": {
-            "bluebird": "^3.5.0",
-            "buffer": "^5.0.5",
-            "decompress": "^4.0.0",
-            "eth-lib": "^0.1.26",
-            "fs-extra": "^4.0.2",
-            "got": "^7.1.0",
-            "mime-types": "^2.1.16",
-            "mkdirp-promise": "^5.0.1",
-            "mock-fs": "^4.1.0",
-            "setimmediate": "^1.0.5",
-            "tar": "^4.0.2",
-            "xhr-request-promise": "^0.1.2"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.1.29",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-              "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "nano-json-stream-parser": "^0.1.2",
-                "servify": "^0.1.12",
-                "ws": "^3.0.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            },
-            "got": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-              "requires": {
-                "decompress-response": "^3.2.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "isurl": "^1.0.0-alpha5",
-                "lowercase-keys": "^1.0.0",
-                "p-cancelable": "^0.3.0",
-                "p-timeout": "^1.1.1",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "url-parse-lax": "^1.0.0",
-                "url-to-options": "^1.0.1"
-              }
-            }
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         },
         "web3": {
           "version": "1.2.4",
@@ -457,9 +872,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.30",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.30.tgz",
-              "integrity": "sha512-euU8QLX0ipj+5mOYa4ZqZoTv+53BY7yTg9I2ZIhDXgiI3M+0n4mdAt9TQCuvxVAgU179g8OsRLaBt0qEi0T6xA=="
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
             }
           }
         },
@@ -634,13 +1049,6 @@
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
           }
         },
         "web3-eth-personal": {
@@ -721,11 +1129,6 @@
             "utf8": "3.0.0"
           },
           "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            },
             "eth-lib": {
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
@@ -736,21 +1139,6 @@
                 "xhr-request-promise": "^0.1.2"
               }
             }
-          }
-        },
-        "whatwg-fetch": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
           }
         }
       }
@@ -785,6 +1173,11 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
           "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
         },
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        },
         "bip39": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
@@ -796,11 +1189,6 @@
             "randombytes": "^2.0.1"
           }
         },
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-        },
         "eth-lib": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
@@ -809,6 +1197,36 @@
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
           }
         },
         "web3-utils": {
@@ -908,14 +1326,6 @@
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "js-sha3": "0.5.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
-        }
       }
     },
     "@ethersproject/logger": {
@@ -953,6 +1363,23 @@
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
         "elliptic": "6.5.3"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
       }
     },
     "@ethersproject/strings": {
@@ -967,9 +1394,9 @@
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.4.tgz",
-      "integrity": "sha512-QvS5CzxmL46D9Y3OlddurYgEIi5mb0eAgrKm5pM074Uz/1qxCYr+Ah12I4hpaciZtCq4Fe12YWZqUFb1vGcH6Q==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.3.tgz",
+      "integrity": "sha512-cqsAAFUQV6iWqfgLL7KCPNfd3pXJPDdYtE6QuBEAIpc7cgbJ7TIDCF/dN+1otfERHJIbjGSNrhh4axKRnSFswg==",
       "dev": true,
       "requires": {
         "@ethersproject/address": "^5.0.3",
@@ -983,596 +1410,51 @@
         "@ethersproject/signing-key": "^5.0.4"
       }
     },
-    "@keep-network/keep-ecdsa": {
-      "version": "1.2.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-rc.3.tgz",
-      "integrity": "sha512-jcMXyZR/eZKNpgrVrD8WBAuq97y11OFFvWsLVNyssZdSRpM8D2GW4m1c2yjEE1gTePDYr4POR0wGCxkgBJ96KQ==",
+    "@keep-network/keep-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0.tgz",
+      "integrity": "sha512-c8efKWPx5da6OSdcm9/uvdDqrfwDcYAExNqPvomhLFC0dATEEFHsr/QOAqiBm4wCZZtWMKt0dYTm5QpGtx5TXQ==",
       "requires": {
-        "@keep-network/keep-core": ">1.3.0-rc <1.3.0",
-        "@keep-network/sortition-pools": "1.1.1",
+        "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
-        "openzeppelin-solidity": "2.3.0",
-        "solidity-bytes-utils": "0.0.7"
+        "openzeppelin-solidity": "2.4.0"
       },
       "dependencies": {
-        "@keep-network/keep-core": {
-          "version": "1.3.0-rc.1",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0-rc.1.tgz",
-          "integrity": "sha512-u12pMnmTRbwx7OYeZOzM3+7U4eE7tRco/FZwv/0kKVdwVFfsETVJD9s4SLOdwUrzzG13YNQHfYpD0blC2EYA3Q==",
-          "requires": {
-            "@openzeppelin/contracts-ethereum-package": "^2.4.0",
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.4.0"
-          },
-          "dependencies": {
-            "openzeppelin-solidity": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
-              "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
-            }
-          }
-        },
-        "@keep-network/sortition-pools": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.1.tgz",
-          "integrity": "sha512-zdaVTew4xfDe65ZfO7B0TibpYVtm6iFB8ixvSqyzT+l6CPSZpj0IH/X0NIKPFTztL1yiibEsAUj3IaeppS3UmA==",
-          "requires": {
-            "@openzeppelin/contracts": "^2.4.0"
-          }
-        },
-        "@openzeppelin/upgrades": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
-          "integrity": "sha512-LzjTQPeljPsgHDPdZyH9cMCbIHZILgd2cpNcYEkdsC2IylBYRHShlbEDXJV9snnqg9JWfzPiKIqyj3XVliwtqQ==",
-          "requires": {
-            "@types/cbor": "^2.0.0",
-            "axios": "^0.18.0",
-            "bignumber.js": "^7.2.0",
-            "cbor": "^4.1.5",
-            "chalk": "^2.4.1",
-            "ethers": "^4.0.20",
-            "glob": "^7.1.3",
-            "lodash": "^4.17.15",
-            "semver": "^5.5.1",
-            "spinnies": "^0.4.2",
-            "truffle-flattener": "^1.4.0",
-            "web3": "1.2.2",
-            "web3-eth": "1.2.2",
-            "web3-eth-contract": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ=="
-        },
-        "bignumber.js": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-        },
-        "eth-lib": {
-          "version": "0.1.29",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-          "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "nano-json-stream-parser": "^0.1.2",
-            "servify": "^0.1.12",
-            "ws": "^3.0.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-          "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        },
-        "eventemitter3": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
         "openzeppelin-solidity": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-        },
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "scrypt-js": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-        },
-        "swarm-js": {
-          "version": "0.1.39",
-          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
-          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
-          "requires": {
-            "bluebird": "^3.5.0",
-            "buffer": "^5.0.5",
-            "decompress": "^4.0.0",
-            "eth-lib": "^0.1.26",
-            "fs-extra": "^4.0.2",
-            "got": "^7.1.0",
-            "mime-types": "^2.1.16",
-            "mkdirp-promise": "^5.0.1",
-            "mock-fs": "^4.1.0",
-            "setimmediate": "^1.0.5",
-            "tar": "^4.0.2",
-            "xhr-request-promise": "^0.1.2"
-          },
-          "dependencies": {
-            "got": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-              "requires": {
-                "decompress-response": "^3.2.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "isurl": "^1.0.0-alpha5",
-                "lowercase-keys": "^1.0.0",
-                "p-cancelable": "^0.3.0",
-                "p-timeout": "^1.1.1",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "url-parse-lax": "^1.0.0",
-                "url-to-options": "^1.0.1"
-              }
-            }
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        },
-        "web3": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
-          "integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
-          "requires": {
-            "@types/node": "^12.6.1",
-            "web3-bzz": "1.2.2",
-            "web3-core": "1.2.2",
-            "web3-eth": "1.2.2",
-            "web3-eth-personal": "1.2.2",
-            "web3-net": "1.2.2",
-            "web3-shh": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-bzz": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
-          "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
-          "requires": {
-            "@types/node": "^10.12.18",
-            "got": "9.6.0",
-            "swarm-js": "0.1.39",
-            "underscore": "1.9.1"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "10.17.30",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.30.tgz",
-              "integrity": "sha512-euU8QLX0ipj+5mOYa4ZqZoTv+53BY7yTg9I2ZIhDXgiI3M+0n4mdAt9TQCuvxVAgU179g8OsRLaBt0qEi0T6xA=="
-            }
-          }
-        },
-        "web3-core": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
-          "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
-          "requires": {
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^12.6.1",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-core-requestmanager": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
-          "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-eth-iban": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
-          "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-promievent": "1.2.2",
-            "web3-core-subscriptions": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
-          "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "eventemitter3": "3.1.2"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
-          "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2",
-            "web3-providers-http": "1.2.2",
-            "web3-providers-ipc": "1.2.2",
-            "web3-providers-ws": "1.2.2"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
-          "integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
-          "requires": {
-            "eventemitter3": "3.1.2",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2"
-          }
-        },
-        "web3-eth": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
-          "integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core": "1.2.2",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-core-subscriptions": "1.2.2",
-            "web3-eth-abi": "1.2.2",
-            "web3-eth-accounts": "1.2.2",
-            "web3-eth-contract": "1.2.2",
-            "web3-eth-ens": "1.2.2",
-            "web3-eth-iban": "1.2.2",
-            "web3-eth-personal": "1.2.2",
-            "web3-net": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.2.tgz",
-          "integrity": "sha512-Yn/ZMgoOLxhTVxIYtPJ0eS6pnAnkTAaJgUJh1JhZS4ekzgswMfEYXOwpMaD5eiqPJLpuxmZFnXnBZlnQ1JMXsw==",
-          "requires": {
-            "ethers": "4.0.0-beta.3",
-            "underscore": "1.9.1",
-            "web3-utils": "1.2.2"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "10.17.30",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.30.tgz",
-              "integrity": "sha512-euU8QLX0ipj+5mOYa4ZqZoTv+53BY7yTg9I2ZIhDXgiI3M+0n4mdAt9TQCuvxVAgU179g8OsRLaBt0qEi0T6xA=="
-            },
-            "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
-              }
-            },
-            "ethers": {
-              "version": "4.0.0-beta.3",
-              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-              "requires": {
-                "@types/node": "^10.3.2",
-                "aes-js": "3.0.0",
-                "bn.js": "^4.4.0",
-                "elliptic": "6.3.3",
-                "hash.js": "1.1.3",
-                "js-sha3": "0.5.7",
-                "scrypt-js": "2.0.3",
-                "setimmediate": "1.0.4",
-                "uuid": "2.0.1",
-                "xmlhttprequest": "1.8.0"
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-            }
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
-          "integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "ethereumjs-common": "^1.3.2",
-            "ethereumjs-tx": "^2.1.1",
-            "scrypt-shim": "github:web3-js/scrypt-shim",
-            "underscore": "1.9.1",
-            "uuid": "3.3.2",
-            "web3-core": "1.2.2",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-utils": "1.2.2"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-            }
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
-          "integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
-          "requires": {
-            "@types/bn.js": "^4.11.4",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.2",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-core-promievent": "1.2.2",
-            "web3-core-subscriptions": "1.2.2",
-            "web3-eth-abi": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-eth-ens": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
-          "integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
-          "requires": {
-            "eth-ens-namehash": "2.0.8",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.2",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-promievent": "1.2.2",
-            "web3-eth-abi": "1.2.2",
-            "web3-eth-contract": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
-          "integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "web3-utils": "1.2.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
-          "integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
-          "requires": {
-            "@types/node": "^12.6.1",
-            "web3-core": "1.2.2",
-            "web3-core-helpers": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-net": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-net": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
-          "integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
-          "requires": {
-            "web3-core": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-utils": "1.2.2"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
-          "integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
-          "requires": {
-            "web3-core-helpers": "1.2.2",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
-          "integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
-          "requires": {
-            "oboe": "2.1.4",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
-          "integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2",
-            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
-          }
-        },
-        "web3-shh": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
-          "integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
-          "requires": {
-            "web3-core": "1.2.2",
-            "web3-core-method": "1.2.2",
-            "web3-core-subscriptions": "1.2.2",
-            "web3-net": "1.2.2"
-          }
-        },
-        "web3-utils": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
-          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            },
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            }
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
-          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
-          }
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
+          "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
         }
       }
     },
-    "@keep-network/tbtc": {
-      "version": "1.1.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0-rc.1.tgz",
-      "integrity": "sha512-v407R7Gj/R8rpk+cOuB9O6izn/rrYSL2HPDqQ4oPFdghYmkRjidoy4qOrzxIhQIvbG9hg4CJJongABrqNlyMhA==",
+    "@keep-network/keep-ecdsa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.1.tgz",
+      "integrity": "sha512-Oz0thgLoemt/nK6dl+MONU7TEoNR3lfbnMY/Aa0oWGcwR5PlNMiBVzYY7OT4oLZIK/MxEHDOWRQAijZEQffI7g==",
       "requires": {
-        "@keep-network/keep-ecdsa": ">1.2.0-rc <1.2.0",
+        "@keep-network/keep-core": "1.3.0",
+        "@keep-network/sortition-pools": "1.1.2",
+        "@openzeppelin/upgrades": "^2.7.2",
+        "openzeppelin-solidity": "2.3.0"
+      }
+    },
+    "@keep-network/sortition-pools": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.2.tgz",
+      "integrity": "sha512-bBaKyxkXDc8kJHq3qeESMrJ02m+Wbh6Uz9qUpWn8Zq3aTZaKXRZfGWT+J71OiBlAdyB4WoHZymrddWHkjImHdQ==",
+      "requires": {
+        "@openzeppelin/contracts": "^2.4.0"
+      }
+    },
+    "@keep-network/tbtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0.tgz",
+      "integrity": "sha512-V4sGR/t61PgkEF11GDZL5QNijVSdDhL7A7larcOSSCmKJOugxd5s+d+NdhYcHZhX9IS58ebtepvZan8TydHUHw==",
+      "requires": {
+        "@keep-network/keep-ecdsa": "1.2.1",
         "@summa-tx/bitcoin-spv-sol": "^3.1.0",
         "@summa-tx/relay-sol": "^2.0.2",
         "openzeppelin-solidity": "2.3.0"
-      },
-      "dependencies": {
-        "openzeppelin-solidity": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-        }
       }
     },
     "@ledgerhq/devices": {
@@ -1669,6 +1551,99 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
       "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
+    },
+    "@openzeppelin/upgrades": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
+      "integrity": "sha512-LzjTQPeljPsgHDPdZyH9cMCbIHZILgd2cpNcYEkdsC2IylBYRHShlbEDXJV9snnqg9JWfzPiKIqyj3XVliwtqQ==",
+      "requires": {
+        "@types/cbor": "^2.0.0",
+        "axios": "^0.18.0",
+        "bignumber.js": "^7.2.0",
+        "cbor": "^4.1.5",
+        "chalk": "^2.4.1",
+        "ethers": "^4.0.20",
+        "glob": "^7.1.3",
+        "lodash": "^4.17.15",
+        "semver": "^5.5.1",
+        "spinnies": "^0.4.2",
+        "truffle-flattener": "^1.4.0",
+        "web3": "1.2.2",
+        "web3-eth": "1.2.2",
+        "web3-eth-contract": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
+          "integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.2",
+            "web3-core": "1.2.2",
+            "web3-eth": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-shh": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
+          "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+            }
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
+          "integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-net": "1.2.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
     },
     "@resolver-engine/core": {
       "version": "0.2.1",
@@ -1774,9 +1749,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@solidity-parser/parser": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.2.tgz",
-      "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.0.tgz",
+      "integrity": "sha512-4Eg1iWe6ZuJC9Ynfd8D2cnu06So0QL6V3i+fgQRqT8twPMr+N+kUvS5K7ILgWpuoAag/jb3r0wBDfmpib+yvaw=="
     },
     "@stablelib/binary": {
       "version": "0.7.2",
@@ -1888,20 +1863,12 @@
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/ethereum-protocol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
-      "integrity": "sha512-vxym5Cnkvms5yRwCDzuaavAtesRflY4oqYDULqQSghLmX5snurmDEz+rbUJbq2vDc4TBvji6dV+891N3VHQXhw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ethereum-protocol/-/ethereum-protocol-1.0.0.tgz",
+      "integrity": "sha512-3DiI3Zxf81CgX+VhxNNFJBv/sfr1BFBKQK2sQ85hU9FwWJJMWV5gRDV79OUNShiwj3tYYIezU94qpucsb3dThQ==",
       "dev": true,
       "requires": {
         "bignumber.js": "7.2.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
-          "dev": true
-        }
       }
     },
     "@types/hdkey": {
@@ -1914,9 +1881,9 @@
       }
     },
     "@types/node": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
+      "version": "12.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+      "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
     },
     "@types/pbkdf2": {
       "version": "3.1.0",
@@ -1933,13 +1900,13 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.49",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-      "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+      "version": "16.9.34",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.34.tgz",
+      "integrity": "sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^2.2.0"
       }
     },
     "@types/secp256k1": {
@@ -1989,18 +1956,32 @@
         "nan": "^2.14.0",
         "typedarray-to-buffer": "^3.1.5",
         "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+        }
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true
+    },
     "abortcontroller-polyfill": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
-      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz",
+      "integrity": "sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==",
       "dev": true
     },
     "abstract-leveldown": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
       "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "dev": true,
       "requires": {
         "xtend": "~4.0.0"
       }
@@ -2015,15 +1996,15 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "aes-js": {
@@ -2032,9 +2013,9 @@
       "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2086,53 +2067,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
       "optional": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
       "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "arg": {
@@ -2162,14 +2106,13 @@
       }
     },
     "asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -2192,6 +2135,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -2200,6 +2144,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "dev": true,
       "requires": {
         "async": "^2.4.0"
       }
@@ -2214,15 +2159,21 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "await-semaphore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
+      "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axios": {
       "version": "0.18.1",
@@ -2262,6 +2213,12 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -2861,6 +2818,14 @@
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
         "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
@@ -2936,10 +2901,10 @@
         "blru": "git+https://github.com/bcoin-org/blru.git#semver:~0.1.6",
         "blst": "git+https://github.com/bcoin-org/blst.git#semver:~0.1.5",
         "bmutex": "git+https://github.com/bcoin-org/bmutex.git#semver:~0.1.6",
-        "brq": "brq@git+https://github.com/bcoin-org/brq.git#534bb2c83fb366ba40ad80bc3de796a174503294",
-        "bs32": "bs32@git+https://github.com/bcoin-org/bs32.git#21cf9c724659dc15df722d2410548828c142f265",
+        "brq": "git+https://github.com/bcoin-org/brq.git#semver:~0.1.7",
+        "bs32": "git+https://github.com/bcoin-org/bs32.git#semver:=0.1.6",
         "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
-        "bsock": "bsock@git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528",
+        "bsock": "git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9",
         "bsocks": "git+https://github.com/bcoin-org/bsocks.git#semver:~0.2.6",
         "btcp": "git+https://github.com/bcoin-org/btcp.git#semver:~0.1.5",
         "buffer-map": "git+https://github.com/chjj/buffer-map.git#semver:~0.0.7",
@@ -3028,6 +2993,15 @@
             "bsert": "~0.0.10"
           }
         },
+        "binet": {
+          "version": "0.3.5",
+          "from": "git+https://github.com/bcoin-org/binet.git#semver:~0.3.5",
+          "bundled": true,
+          "requires": {
+            "bs32": "~0.1.5",
+            "bsert": "~0.0.10"
+          }
+        },
         "blgr": {
           "version": "0.1.7",
           "from": "git+https://github.com/bcoin-org/blgr.git#semver:~0.1.7",
@@ -3060,9 +3034,34 @@
             "bsert": "~0.0.10"
           }
         },
+        "brq": {
+          "version": "0.1.8",
+          "from": "git+https://github.com/bcoin-org/brq.git#semver:~0.1.7",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bs32": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/bs32.git#semver:=0.1.6",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
         "bsert": {
-          "version": "git+https://github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc",
-          "from": "git+https://github.com/chjj/bsert.git#semver:~0.0.10"
+          "version": "0.0.10",
+          "from": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
+          "bundled": true
+        },
+        "bsock": {
+          "version": "0.1.9",
+          "from": "git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
         },
         "bsocks": {
           "version": "0.2.6",
@@ -3146,6 +3145,13 @@
       "requires": {
         "bufio": "~1.0.7",
         "loady": "~0.0.5"
+      },
+      "dependencies": {
+        "bufio": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+          "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+        }
       }
     },
     "bfilter": {
@@ -3158,13 +3164,17 @@
         "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
       },
       "dependencies": {
+        "bcrypto": {
+          "version": "git+https://github.com/bcoin-org/bcrypto.git#827c1926107067159b812012b54d4e8f00d5f975",
+          "from": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
+          "requires": {
+            "bufio": "~1.0.7",
+            "loady": "~0.0.5"
+          }
+        },
         "bufio": {
           "version": "git+https://github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984",
           "from": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6"
-        },
-        "loady": {
-          "version": "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5",
-          "from": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
         }
       }
     },
@@ -3179,25 +3189,14 @@
       "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
     },
     "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "binet": {
-      "version": "git+https://github.com/bcoin-org/binet.git#d3decfb7a7257abdfb03c3a9c091499b2ebff0e1",
-      "from": "git+https://github.com/bcoin-org/binet.git#semver:~0.3.5",
-      "requires": {
-        "bs32": "~0.1.5",
-        "bsert": "~0.0.10"
-      }
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
     },
     "bip32": {
       "version": "2.0.5",
@@ -3224,6 +3223,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.6.0.tgz",
       "integrity": "sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==",
+      "dev": true,
       "requires": {
         "create-hash": "^1.1.0",
         "pbkdf2": "^3.0.9",
@@ -3236,21 +3236,17 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-      "dev": true,
-      "optional": true,
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "blakejs": {
@@ -3271,11 +3267,6 @@
         "typescript": "^3.6.4"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ=="
-        },
         "typescript": {
           "version": "3.9.7",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
@@ -3289,9 +3280,9 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -3308,21 +3299,6 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-        }
       }
     },
     "brace-expansion": {
@@ -3387,6 +3363,24 @@
         "randombytes": "^2.0.1"
       }
     },
+    "browserify-sha3": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
+      "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
+      "dev": true,
+      "requires": {
+        "js-sha3": "^0.6.1",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
+          "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
+          "dev": true
+        }
+      }
+    },
     "browserify-sign": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
@@ -3404,9 +3398,40 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.9",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -3418,20 +3443,6 @@
       "requires": {
         "caniuse-lite": "^1.0.30000844",
         "electron-to-chromium": "^1.3.47"
-      }
-    },
-    "brq": {
-      "version": "git+https://github.com/bcoin-org/brq.git#534bb2c83fb366ba40ad80bc3de796a174503294",
-      "from": "brq@git+https://github.com/bcoin-org/brq.git#534bb2c83fb366ba40ad80bc3de796a174503294",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "bs32": {
-      "version": "git+https://github.com/bcoin-org/bs32.git#21cf9c724659dc15df722d2410548828c142f265",
-      "from": "bs32@git+https://github.com/bcoin-org/bs32.git#21cf9c724659dc15df722d2410548828c142f265",
-      "requires": {
-        "bsert": "~0.0.10"
       }
     },
     "bs58": {
@@ -3456,12 +3467,11 @@
       "version": "git+https://github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc",
       "from": "git+https://github.com/chjj/bsert.git#semver:~0.0.10"
     },
-    "bsock": {
-      "version": "git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528",
-      "from": "bsock@git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true
     },
     "buffer": {
       "version": "5.6.0",
@@ -3516,18 +3526,10 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "bufferutil": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
-      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
-      "requires": {
-        "node-gyp-build": "~3.7.0"
-      }
-    },
     "bufio": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
+      "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -3549,9 +3551,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -3575,9 +3577,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001124",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-      "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
+      "version": "1.0.30001025",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
+      "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
       "dev": true
     },
     "caseless": {
@@ -3594,6 +3596,13 @@
         "commander": "^3.0.0",
         "json-text-sequence": "^0.1",
         "nofilter": "^1.0.3"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        }
       }
     },
     "chai": {
@@ -3634,14 +3643,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+      "dev": true,
       "requires": {
         "functional-red-black-tree": "^1.0.1"
       }
     },
     "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "cids": {
       "version": "0.7.5",
@@ -3692,9 +3702,9 @@
       }
     },
     "cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -3711,11 +3721,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -3745,7 +3750,8 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
     },
     "clone-response": {
       "version": "1.0.2",
@@ -3819,45 +3825,12 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
       "optional": true
     },
     "content-disposition": {
@@ -3959,6 +3932,22 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
       }
     },
     "create-hash": {
@@ -4047,9 +4036,9 @@
       "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
     },
     "csstype": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
+      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
       "dev": true
     },
     "currency-symbol-map": {
@@ -4123,67 +4112,6 @@
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
         "tar-stream": "^1.5.2"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        },
-        "tar-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-          "requires": {
-            "bl": "^1.0.0",
-            "buffer-alloc": "^1.2.0",
-            "end-of-stream": "^1.0.0",
-            "fs-constants": "^1.0.0",
-            "readable-stream": "^2.3.0",
-            "to-buffer": "^1.1.1",
-            "xtend": "^4.0.0"
-          }
-        }
       }
     },
     "decompress-tarbz2": {
@@ -4254,6 +4182,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -4267,7 +4196,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "optional": true
     },
     "deep-is": {
@@ -4285,6 +4213,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "dev": true,
       "requires": {
         "abstract-leveldown": "~2.6.0"
       }
@@ -4300,7 +4229,8 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -4311,7 +4241,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
       "optional": true
     },
     "delimit-stream": {
@@ -4351,7 +4280,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true,
       "optional": true
     },
     "detect-node": {
@@ -4385,9 +4313,9 @@
       }
     },
     "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "dotenv": {
       "version": "8.2.0",
@@ -4398,6 +4326,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
       "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -4406,7 +4335,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "dev": true,
       "requires": {
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
@@ -4433,9 +4361,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.564",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz",
-      "integrity": "sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==",
+      "version": "1.3.345",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
+      "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
       "dev": true
     },
     "electrum-client-js": {
@@ -4446,9 +4374,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -4460,10 +4388,9 @@
       }
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4471,11 +4398,12 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
-        "iconv-lite": "^0.6.2"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -4490,44 +4418,27 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
-      },
-      "dependencies": {
-        "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        }
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -4639,15 +4550,6 @@
             "ms": "^2.1.1"
           }
         },
-        "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.8.1"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4670,9 +4572,9 @@
           }
         },
         "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
           "dev": true
         }
       }
@@ -4695,9 +4597,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -4710,18 +4612,18 @@
       "dev": true
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -4738,9 +4640,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
@@ -4760,37 +4662,21 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
-        "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
-        }
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
-        }
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -4823,6 +4709,51 @@
         "json-rpc-engine": "^3.6.0",
         "pify": "^2.3.0",
         "tape": "^4.6.3"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
       }
     },
     "eth-ens-namehash": {
@@ -4832,12 +4763,123 @@
       "requires": {
         "idna-uts46-hx": "^2.3.1",
         "js-sha3": "^0.5.7"
+      }
+    },
+    "eth-json-rpc-errors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz",
+      "integrity": "sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "eth-json-rpc-filters": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz",
+      "integrity": "sha512-GkXb2h6STznD+AmMzblwXgm1JMvjdK9PTIXG7BvIkTlXQ9g0QOxuU1iQRYHoslF9S30BYBSoLSisAYPdLggW+A==",
+      "dev": true,
+      "requires": {
+        "await-semaphore": "^0.1.3",
+        "eth-json-rpc-middleware": "^4.1.4",
+        "eth-query": "^2.1.2",
+        "json-rpc-engine": "^5.1.3",
+        "lodash.flatmap": "^4.5.0",
+        "safe-event-emitter": "^1.0.1"
       },
       "dependencies": {
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "eth-json-rpc-errors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+          "dev": true,
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        },
+        "eth-json-rpc-middleware": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz",
+          "integrity": "sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==",
+          "dev": true,
+          "requires": {
+            "btoa": "^1.2.1",
+            "clone": "^2.1.1",
+            "eth-json-rpc-errors": "^1.0.1",
+            "eth-query": "^2.1.2",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.7",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.6.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^5.1.3",
+            "json-stable-stringify": "^1.0.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "json-rpc-engine": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.3.0.tgz",
+          "integrity": "sha512-+diJ9s8rxB+fbJhT7ZEf8r8spaLRignLd8jTgQ/h5JSGppAHGtNMZtCoabipCaleR1B3GTGxbXBOqhaJSGmPGQ==",
+          "dev": true,
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -4872,15 +4914,63 @@
         "json-stable-stringify": "^1.0.1",
         "promise-to-callback": "^1.0.0",
         "tape": "^4.6.3"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
       }
     },
     "eth-lib": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
       "requires": {
         "bn.js": "^4.11.6",
         "elliptic": "^6.4.0",
+        "nano-json-stream-parser": "^0.1.2",
+        "servify": "^0.1.12",
+        "ws": "^3.0.0",
         "xhr-request-promise": "^0.1.2"
       }
     },
@@ -4894,6 +4984,15 @@
         "xtend": "^4.0.1"
       }
     },
+    "eth-rpc-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
+      "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "eth-sig-util": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
@@ -4902,6 +5001,35 @@
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
       }
     },
     "eth-tx-summary": {
@@ -4920,6 +5048,51 @@
         "ethereumjs-util": "^5.0.1",
         "ethereumjs-vm": "^2.6.0",
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
       }
     },
     "ethereum-bloom-filters": {
@@ -4928,12 +5101,20 @@
       "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
       "requires": {
         "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
       }
     },
     "ethereum-common": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+      "dev": true
     },
     "ethereum-cryptography": {
       "version": "0.1.3",
@@ -4955,16 +5136,69 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+        },
+        "secp256k1": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        }
       }
     },
     "ethereum-types": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-3.2.0.tgz",
-      "integrity": "sha512-osxikvWF2CuHauo2jiBpGalLXbCj5xWm2WcNr+Z4sNTk7z6DArPNXwsgANu2bA+aAsqSSF4NgsNx8JS1d3xdOQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-3.1.0.tgz",
+      "integrity": "sha512-E4lBfxzRSFjd2OM+BATc0b3nN+xWVpAQhBCwSNS9kbsXVPV2LNhIduwCR8Poc8seQukFfuXp0QoVXOlQbUS2pQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "bignumber.js": "~9.0.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        }
       }
     },
     "ethereumjs-abi": {
@@ -4974,39 +5208,53 @@
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
       }
     },
     "ethereumjs-account": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
       "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+      "dev": true,
       "requires": {
         "ethereumjs-util": "^5.0.0",
         "rlp": "^2.0.0",
         "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
       }
     },
     "ethereumjs-block": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "dev": true,
       "requires": {
         "async": "^2.0.1",
         "ethereum-common": "0.2.0",
@@ -5015,45 +5263,86 @@
         "merkle-patricia-tree": "^2.1.2"
       },
       "dependencies": {
-        "ethereum-common": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          },
+          "dependencies": {
+            "ethereum-common": {
+              "version": "0.0.18",
+              "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+              "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+              "dev": true
+            }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
         }
       }
     },
     "ethereumjs-common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
+      "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
     },
     "ethereumjs-tx": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
+        "ethereumjs-common": "^1.5.0",
+        "ethereumjs-util": "^6.0.0"
       }
     },
     "ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+      "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
       "requires": {
+        "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
+        "ethjs-util": "0.1.6",
+        "keccak": "^2.0.0",
+        "rlp": "^2.2.3",
+        "secp256k1": "^3.0.1"
       }
     },
     "ethereumjs-vm": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
       "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
+      "dev": true,
       "requires": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
@@ -5072,6 +5361,7 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
           "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
+          "dev": true,
           "requires": {
             "async": "^2.0.1",
             "ethereumjs-common": "^1.5.0",
@@ -5081,93 +5371,33 @@
           },
           "dependencies": {
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             }
           }
         },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
           "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
           }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
-      }
-    },
-    "ethereumjs-wallet": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
-      "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
-      "requires": {
-        "aes-js": "^3.1.1",
-        "bs58check": "^2.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^6.0.0",
-        "randombytes": "^2.0.6",
-        "safe-buffer": "^5.1.2",
-        "scryptsy": "^1.2.1",
-        "utf8": "^3.0.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "aes-js": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-          "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        },
-        "scryptsy": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-          "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
-          "requires": {
-            "pbkdf2": "^3.0.3"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -5187,6 +5417,20 @@
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -5196,20 +5440,10 @@
             "minimalistic-assert": "^1.0.0"
           }
         },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -5239,15 +5473,15 @@
       }
     },
     "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
-      "dev": true
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -5302,11 +5536,6 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -5323,9 +5552,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
         }
       }
     },
@@ -5343,17 +5572,6 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "extsprintf": {
@@ -5365,14 +5583,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+      "dev": true,
       "requires": {
         "checkpoint-store": "^1.1.0"
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -5389,6 +5608,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
     },
     "fd-slicer": {
@@ -5478,9 +5703,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "follow-redirects": {
@@ -5505,6 +5730,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -5581,7 +5807,8 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "futoin-hkdf": {
       "version": "1.3.2",
@@ -5589,9 +5816,9 @@
       "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw=="
     },
     "ganache-core": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.11.3.tgz",
-      "integrity": "sha512-SsFJUnyiZI+jW3I43XluXi3TvJC3Ke6vZkvN6NjbWpXvi6dOrmafkyq9Rq07+Qrri6BLGKWoZcG8HfH6ietuqg==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.10.2.tgz",
+      "integrity": "sha512-4XEO0VsqQ1+OW7Za5fQs9/Kk7o8M0T1sRfFSF8h9NeJ2ABaqMO5waqxf567ZMcSkRKaTjUucBSz83xNfZv1HDg==",
       "dev": true,
       "requires": {
         "abstract-leveldown": "3.0.0",
@@ -5608,13 +5835,12 @@
         "ethereumjs-common": "1.5.0",
         "ethereumjs-tx": "2.1.2",
         "ethereumjs-util": "6.2.0",
-        "ethereumjs-vm": "4.2.0",
+        "ethereumjs-vm": "4.1.3",
         "ethereumjs-wallet": "0.6.3",
         "heap": "0.2.6",
         "level-sublevel": "6.6.4",
         "levelup": "3.1.1",
         "lodash": "4.17.14",
-        "lru-cache": "5.1.1",
         "merkle-patricia-tree": "2.3.2",
         "seedrandom": "3.0.1",
         "source-map-support": "0.5.12",
@@ -5625,31 +5851,30 @@
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
           "requires": {
-            "@babel/highlight": "^7.10.4"
+            "@babel/highlight": "^7.8.3"
           }
         },
         "@babel/core": {
-          "version": "7.11.1",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-          "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+          "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.0",
-            "@babel/helper-module-transforms": "^7.11.0",
-            "@babel/helpers": "^7.10.4",
-            "@babel/parser": "^7.11.1",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.11.0",
-            "@babel/types": "^7.11.0",
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helpers": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.19",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
@@ -5664,12 +5889,9 @@
               }
             },
             "json5": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-              "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-              "requires": {
-                "minimist": "^1.2.5"
-              }
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+              "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ=="
             },
             "lodash": {
               "version": "4.17.19",
@@ -5689,12 +5911,13 @@
           }
         },
         "@babel/generator": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-          "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
           "requires": {
-            "@babel/types": "^7.11.0",
+            "@babel/types": "^7.8.3",
             "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
@@ -5711,38 +5934,32 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.10.4",
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-member-expression-to-functions": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
-          "requires": {
-            "@babel/types": "^7.11.0"
-          }
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q=="
         },
         "@babel/helper-module-imports": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-          "requires": {
-            "@babel/types": "^7.10.4"
-          }
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw=="
         },
         "@babel/helper-module-transforms": {
           "version": "7.11.0",
@@ -5752,9 +5969,6 @@
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.11.0",
             "lodash": "^4.17.19"
           },
           "dependencies": {
@@ -5768,10 +5982,7 @@
         "@babel/helper-optimise-call-expression": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-          "requires": {
-            "@babel/types": "^7.10.4"
-          }
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg=="
         },
         "@babel/helper-replace-supers": {
           "version": "7.10.4",
@@ -5779,26 +5990,20 @@
           "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
           "requires": {
             "@babel/helper-member-expression-to-functions": "^7.10.4",
-            "@babel/helper-optimise-call-expression": "^7.10.4",
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/helper-optimise-call-expression": "^7.10.4"
           }
         },
         "@babel/helper-simple-access": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-          "requires": {
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4"
-          }
+          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw=="
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
           "requires": {
-            "@babel/types": "^7.11.0"
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-validator-identifier": {
@@ -5807,22 +6012,22 @@
           "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/helpers": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
+          "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
           "requires": {
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
             "js-tokens": "^4.0.0"
           },
           "dependencies": {
@@ -5860,34 +6065,34 @@
           }
         },
         "@babel/parser": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
-          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+          "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
         },
         "@babel/template": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/traverse": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-          "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.0",
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.11.0",
-            "@babel/types": "^7.11.0",
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "debug": {
@@ -5911,12 +6116,12 @@
           }
         },
         "@babel/types": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -5933,13 +6138,12 @@
           }
         },
         "@istanbuljs/load-nyc-config": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-          "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+          "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
           "requires": {
             "camelcase": "^5.3.1",
             "find-up": "^4.1.0",
-            "get-package-type": "^0.1.0",
             "js-yaml": "^3.13.1",
             "resolve-from": "^5.0.0"
           },
@@ -5967,9 +6171,9 @@
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -6052,9 +6256,9 @@
           "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
         },
         "@types/node": {
-          "version": "14.0.27",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-          "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+          "version": "13.5.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
+          "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA=="
         },
         "@types/parse-json": {
           "version": "4.0.0",
@@ -6065,7 +6269,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
           "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-          "dev": true,
           "requires": {
             "@types/node": "*"
           }
@@ -6074,7 +6277,6 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
           "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-          "dev": true,
           "requires": {
             "@types/node": "*"
           }
@@ -6132,6 +6334,11 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "nan": {
+              "version": "2.14.1",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
             }
           }
         },
@@ -6322,14 +6529,14 @@
           }
         },
         "acorn": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
         },
         "acorn-jsx": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-          "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+          "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
         },
         "aes-js": {
           "version": "3.1.2",
@@ -6355,9 +6562,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -6371,9 +6578,9 @@
           "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
         },
         "ajv-keywords": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
         },
         "ansi-colors": {
           "version": "1.1.0",
@@ -6385,12 +6592,9 @@
           }
         },
         "ansi-escapes": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "requires": {
-            "type-fest": "^0.11.0"
-          },
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
           "dependencies": {
             "type-fest": {
               "version": "0.11.0",
@@ -6733,9 +6937,9 @@
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-          "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "babel-code-frame": {
           "version": "6.26.0",
@@ -7338,12 +7542,12 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             },
             "source-map": {
@@ -7529,10 +7733,9 @@
           }
         },
         "base-x": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-          "dev": true,
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
+          "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -7656,8 +7859,7 @@
         "blakejs": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-          "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
-          "dev": true
+          "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
         },
         "bluebird": {
           "version": "3.7.2",
@@ -7665,9 +7867,9 @@
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         },
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "body-parser": {
           "version": "1.19.0",
@@ -7800,25 +8002,23 @@
           }
         },
         "browserify-sign": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-          "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+          "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
           "requires": {
-            "bn.js": "^5.1.1",
-            "browserify-rsa": "^4.0.1",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "elliptic": "^6.5.3",
-            "inherits": "^2.0.4",
-            "parse-asn1": "^5.1.5",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
           },
           "dependencies": {
             "bn.js": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-              "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+              "version": "4.11.9",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
             }
           }
         },
@@ -7844,7 +8044,6 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
           "requires": {
             "base-x": "^3.0.2"
           }
@@ -7853,7 +8052,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
           "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-          "dev": true,
           "requires": {
             "bs58": "^4.0.0",
             "create-hash": "^1.1.0",
@@ -7861,9 +8059,9 @@
           }
         },
         "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -7954,7 +8152,6 @@
             "glob": "^7.1.4",
             "graceful-fs": "^4.2.2",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
             "minipass": "^3.0.0",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
@@ -7977,19 +8174,19 @@
               }
             },
             "minipass": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-              "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
               "requires": {
                 "yallist": "^4.0.0"
               }
             },
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             },
             "p-map": {
@@ -8094,9 +8291,9 @@
           },
           "dependencies": {
             "make-dir": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-              "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
               "requires": {
                 "semver": "^6.0.0"
               }
@@ -8120,9 +8317,9 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001111",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
-          "integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==",
+          "version": "1.0.30001023",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+          "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
           "dev": true
         },
         "caseless": {
@@ -8173,12 +8370,19 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+            }
           }
         },
         "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
         },
         "chrome-trace-event": {
           "version": "1.0.2",
@@ -8253,9 +8457,9 @@
           }
         },
         "cli-width": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "cliui": {
           "version": "3.2.0",
@@ -8396,14 +8600,17 @@
           }
         },
         "command-exists": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-          "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+          "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
         },
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
         },
         "commondir": {
           "version": "1.0.1",
@@ -8544,11 +8751,11 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             }
           }
@@ -8574,9 +8781,9 @@
           "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
         },
         "core-js-pure": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-          "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+          "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
           "dev": true
         },
         "core-util-is": {
@@ -8606,9 +8813,9 @@
           },
           "dependencies": {
             "parse-json": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-              "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+              "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
               "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -8624,24 +8831,23 @@
           }
         },
         "coveralls": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-          "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
+          "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
           "requires": {
             "js-yaml": "^3.13.1",
             "lcov-parse": "^1.0.0",
             "log-driver": "^1.2.7",
-            "minimist": "^1.2.5",
-            "request": "^2.88.2"
+            "request": "^2.88.0"
           }
         },
         "create-ecdh": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-          "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+          "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
           "requires": {
             "bn.js": "^4.1.0",
-            "elliptic": "^6.5.3"
+            "elliptic": "^6.0.0"
           }
         },
         "create-hash": {
@@ -8688,9 +8894,9 @@
           }
         },
         "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -8771,9 +8977,9 @@
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "decompress": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
-          "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+          "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
           "requires": {
             "decompress-tar": "^4.0.0",
             "decompress-tarbz2": "^4.0.0",
@@ -9086,9 +9292,9 @@
           }
         },
         "dom-walk": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-          "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+          "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
         },
         "domain-browser": {
           "version": "1.2.0",
@@ -9189,9 +9395,9 @@
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "electron-to-chromium": {
-          "version": "1.3.521",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.521.tgz",
-          "integrity": "sha512-7/Cf5jUuAfLRY8SjfRES/6+9BDvmHAB2YQotCAaXK0IEacpjoSlyosPoC4s7lfb7vIOBubXvsssu8+8qaRGjcg==",
+          "version": "1.3.341",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz",
+          "integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g==",
           "dev": true
         },
         "elegant-spinner": {
@@ -9200,9 +9406,9 @@
           "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
         },
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -9219,9 +9425,9 @@
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
         },
         "encodeurl": {
           "version": "1.0.2",
@@ -9229,21 +9435,21 @@
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "encoding": {
-          "version": "0.1.13",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-          "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "dev": true,
           "requires": {
-            "iconv-lite": "^0.6.2"
+            "iconv-lite": "~0.4.13"
           },
           "dependencies": {
             "iconv-lite": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-              "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+              "version": "0.4.24",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             }
           }
@@ -9281,9 +9487,9 @@
           }
         },
         "enhanced-resolve": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-          "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+          "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
           "requires": {
             "graceful-fs": "^4.1.2",
             "memory-fs": "^0.5.0",
@@ -9350,21 +9556,21 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
             "object-inspect": "^1.7.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
           },
           "dependencies": {
             "object-keys": {
@@ -9535,27 +9741,27 @@
               }
             },
             "glob-parent": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-              "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+              "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
               "requires": {
                 "is-glob": "^4.0.1"
               }
             },
             "globals": {
-              "version": "12.4.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-              "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+              "version": "12.3.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+              "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
               "requires": {
                 "type-fest": "^0.8.1"
               }
             },
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             },
             "path-key": {
@@ -9605,9 +9811,9 @@
           "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA=="
         },
         "eslint-import-resolver-node": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-          "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+          "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
           "requires": {
             "debug": "^2.6.9",
             "resolve": "^1.13.1"
@@ -9629,9 +9835,9 @@
           }
         },
         "eslint-module-utils": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-          "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+          "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
           "requires": {
             "debug": "^2.6.9",
             "pkg-dir": "^2.0.0"
@@ -9653,26 +9859,26 @@
           }
         },
         "eslint-plugin-es": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-          "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
+          "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
           "requires": {
             "eslint-utils": "^2.0.0",
             "regexpp": "^3.0.0"
           },
           "dependencies": {
             "eslint-utils": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-              "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+              "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
               "requires": {
                 "eslint-visitor-keys": "^1.1.0"
               }
             },
             "regexpp": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-              "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+              "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
             }
           }
         },
@@ -9794,17 +10000,17 @@
           },
           "dependencies": {
             "eslint-utils": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-              "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+              "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
               "requires": {
                 "eslint-visitor-keys": "^1.1.0"
               }
             },
             "ignore": {
-              "version": "5.1.8",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-              "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+              "version": "5.1.4",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+              "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
             },
             "semver": {
               "version": "6.3.0",
@@ -9824,9 +10030,9 @@
           "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ=="
         },
         "eslint-scope": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
@@ -9841,17 +10047,17 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
         },
         "espree": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+          "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
           "requires": {
-            "acorn": "^7.1.1",
-            "acorn-jsx": "^5.2.0",
+            "acorn": "^7.1.0",
+            "acorn-jsx": "^5.1.0",
             "eslint-visitor-keys": "^1.1.0"
           }
         },
@@ -9861,12 +10067,9 @@
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "esquery": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-          "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
-          "requires": {
-            "estraverse": "^5.1.0"
-          },
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+          "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
           "dependencies": {
             "estraverse": {
               "version": "5.2.0",
@@ -9924,18 +10127,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             },
             "pify": {
@@ -10044,18 +10247,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             },
             "ethereumjs-vm": {
@@ -10091,18 +10294,30 @@
                   },
                   "dependencies": {
                     "ethereumjs-util": {
-                      "version": "5.2.1",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
                       "dev": true,
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
-                        "elliptic": "^6.5.2",
-                        "ethereum-cryptography": "^0.1.3",
                         "ethjs-util": "^0.1.3",
+                        "keccak": "^1.0.2",
                         "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
+                      }
+                    },
+                    "keccak": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
                       }
                     }
                   }
@@ -10118,18 +10333,38 @@
                   }
                 },
                 "ethereumjs-util": {
-                  "version": "6.2.1",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "keccak": "^2.0.0",
+                    "rlp": "^2.2.3",
+                    "secp256k1": "^3.0.1"
+                  }
+                },
+                "keccak": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+                  "dev": true,
+                  "requires": {
+                    "bindings": "^1.5.0",
+                    "inherits": "^2.0.4",
+                    "nan": "^2.14.0",
+                    "safe-buffer": "^5.2.0"
+                  },
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.14.1",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+                      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+                      "dev": true
+                    }
                   }
                 }
               }
@@ -10184,33 +10419,45 @@
               },
               "dependencies": {
                 "ethereumjs-util": {
-                  "version": "4.5.1",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-                  "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
+                  "version": "4.5.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+                  "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
                   "dev": true,
                   "requires": {
                     "bn.js": "^4.8.0",
                     "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
-                    "rlp": "^2.0.0"
+                    "keccakjs": "^0.2.0",
+                    "rlp": "^2.0.0",
+                    "secp256k1": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "keccakjs": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
+                      "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
+                      "dev": true,
+                      "requires": {
+                        "browserify-sha3": "^0.0.4",
+                        "sha3": "^1.2.2"
+                      }
+                    }
                   }
                 }
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             }
           }
@@ -10282,18 +10529,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             },
             "ethereumjs-vm": {
@@ -10329,18 +10576,30 @@
                   },
                   "dependencies": {
                     "ethereumjs-util": {
-                      "version": "5.2.1",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
                       "dev": true,
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
-                        "elliptic": "^6.5.2",
-                        "ethereum-cryptography": "^0.1.3",
                         "ethjs-util": "^0.1.3",
+                        "keccak": "^1.0.2",
                         "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
+                      }
+                    },
+                    "keccak": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
                       }
                     }
                   }
@@ -10356,18 +10615,38 @@
                   }
                 },
                 "ethereumjs-util": {
-                  "version": "6.2.1",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "keccak": "^2.0.0",
+                    "rlp": "^2.2.3",
+                    "secp256k1": "^3.0.1"
+                  }
+                },
+                "keccak": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+                  "dev": true,
+                  "requires": {
+                    "bindings": "^1.5.0",
+                    "inherits": "^2.0.4",
+                    "nan": "^2.14.0",
+                    "safe-buffer": "^5.2.0"
+                  },
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.14.1",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+                      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+                      "dev": true
+                    }
                   }
                 }
               }
@@ -10375,54 +10654,80 @@
           }
         },
         "ethashjs": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
-          "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
+          "integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
           "dev": true,
           "requires": {
-            "async": "^2.1.2",
-            "buffer-xor": "^2.0.1",
-            "ethereumjs-util": "^7.0.2",
+            "async": "^1.4.2",
+            "buffer-xor": "^1.0.3",
+            "ethereumjs-util": "^4.0.1",
             "miller-rabin": "^4.0.0"
           },
           "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            },
             "bn.js": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-              "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
-              "dev": true
+              "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
             },
             "buffer-xor": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
-              "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+              "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+              "dev": true
             },
             "ethereumjs-util": {
-              "version": "7.0.4",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz",
-              "integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
               "dev": true,
               "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^5.1.2",
+                "bn.js": "^4.8.0",
                 "create-hash": "^1.1.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "^2.2.4"
+                "keccakjs": "^0.2.0",
+                "rlp": "^2.0.0",
+                "secp256k1": "^3.0.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.9",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                  "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                  "dev": true
+                },
+                "keccakjs": {
+                  "version": "0.2.3",
+                  "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
+                  "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
+                  "dev": true,
+                  "requires": {
+                    "browserify-sha3": "^0.0.4",
+                    "sha3": "^1.2.2"
+                  }
+                }
               }
             }
           }
         },
         "ethereum-bloom-filters": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
-          "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
+          "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
           "requires": {
             "js-sha3": "^0.8.0"
+          },
+          "dependencies": {
+            "js-sha3": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+              "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+            }
           }
         },
         "ethereum-common": {
@@ -10435,7 +10740,6 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
           "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
           "requires": {
             "@types/pbkdf2": "^3.0.0",
             "@types/secp256k1": "^4.0.1",
@@ -10445,12 +10749,9 @@
             "create-hash": "^1.2.0",
             "create-hmac": "^1.1.7",
             "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
             "pbkdf2": "^3.0.17",
             "randombytes": "^2.1.0",
             "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
             "setimmediate": "^1.0.5"
           }
         },
@@ -10489,38 +10790,64 @@
           },
           "dependencies": {
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             }
           }
         },
         "ethereumjs-blockchain": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
-          "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz",
+          "integrity": "sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==",
           "dev": true,
           "requires": {
             "async": "^2.6.1",
             "ethashjs": "~0.0.7",
             "ethereumjs-block": "~2.2.2",
             "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.1.0",
+            "ethereumjs-util": "~6.1.0",
             "flow-stoplight": "^1.0.0",
             "level-mem": "^3.0.1",
             "lru-cache": "^5.1.1",
             "rlp": "^2.2.2",
             "semaphore": "^1.1.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "lru-cache": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+              "dev": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            }
           }
         },
         "ethereumjs-common": {
@@ -10562,6 +10889,11 @@
                 "safe-buffer": "^5.2.0"
               }
             },
+            "nan": {
+              "version": "2.14.1",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+            },
             "secp256k1": {
               "version": "3.8.0",
               "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
@@ -10580,9 +10912,9 @@
           }
         },
         "ethereumjs-vm": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
-          "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.1.3.tgz",
+          "integrity": "sha512-RTrD0y7My4O6Qr1P2ZIsMfD6RzL6kU/RhBZ0a5XrPzAeR61crBS7or66ohDrvxDI/rDBxMi+6SnsELih6fzalw==",
           "dev": true,
           "requires": {
             "async": "^2.1.2",
@@ -10717,9 +11049,9 @@
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
         },
         "events": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+          "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
         },
         "evp_bytestokey": {
           "version": "1.0.3",
@@ -11022,9 +11354,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -11066,14 +11398,14 @@
           }
         },
         "figgy-pudding": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-          "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
         },
         "figures": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
@@ -11152,12 +11484,12 @@
           }
         },
         "find-cache-dir": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-          "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+          "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
           "requires": {
             "commondir": "^1.0.1",
-            "make-dir": "^3.0.2",
+            "make-dir": "^3.0.0",
             "pkg-dir": "^4.1.0"
           },
           "dependencies": {
@@ -11179,17 +11511,17 @@
               }
             },
             "make-dir": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-              "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
               "requires": {
                 "semver": "^6.0.0"
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -11303,9 +11635,9 @@
           }
         },
         "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+          "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
         },
         "flow-stoplight": {
           "version": "1.0.0",
@@ -11465,9 +11797,9 @@
           }
         },
         "fromentries": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
-          "integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw=="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+          "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ=="
         },
         "fs-constants": {
           "version": "1.0.0",
@@ -11553,13 +11885,14 @@
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+          "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
-            "nan": "^2.12.1"
+            "nan": "^2.12.1",
+            "node-pre-gyp": "*"
           }
         },
         "function-bind": {
@@ -11708,9 +12041,9 @@
           }
         },
         "glob-watcher": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
-          "integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+          "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
@@ -11718,7 +12051,6 @@
             "chokidar": "^2.0.0",
             "is-negated-glob": "^1.0.0",
             "just-debounce": "^1.0.0",
-            "normalize-path": "^3.0.0",
             "object.defaults": "^1.1.0"
           }
         },
@@ -11787,9 +12119,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "growl": {
           "version": "1.10.5",
@@ -11809,9 +12141,9 @@
           },
           "dependencies": {
             "gulp-cli": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
-              "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+              "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
               "dev": true,
               "requires": {
                 "ansi-colors": "^1.0.1",
@@ -11822,7 +12154,7 @@
                 "copy-props": "^2.0.1",
                 "fancy-log": "^1.3.2",
                 "gulplog": "^1.0.0",
-                "interpret": "^1.4.0",
+                "interpret": "^1.1.0",
                 "isobject": "^3.0.1",
                 "liftoff": "^3.1.0",
                 "matchdep": "^2.0.0",
@@ -11830,7 +12162,7 @@
                 "pretty-hrtime": "^1.0.0",
                 "replace-homedir": "^1.0.0",
                 "semver-greatest-satisfied-range": "^1.1.0",
-                "v8flags": "^3.2.0",
+                "v8flags": "^3.0.1",
                 "yargs": "^7.1.0"
               }
             }
@@ -11851,11 +12183,11 @@
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
           "requires": {
-            "ajv": "^6.12.3",
+            "ajv": "^6.5.5",
             "har-schema": "^2.0.0"
           }
         },
@@ -11928,13 +12260,12 @@
           }
         },
         "hash-base": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-          "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "hash.js": {
@@ -11947,9 +12278,9 @@
           }
         },
         "hasha": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
-          "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+          "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
           "requires": {
             "is-stream": "^2.0.0",
             "type-fest": "^0.8.0"
@@ -11963,17 +12294,24 @@
           }
         },
         "hdkey": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
-          "integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.1.tgz",
+          "integrity": "sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "bs58check": "^2.1.2",
+            "coinstring": "^2.0.0",
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
           },
           "dependencies": {
+            "nan": {
+              "version": "2.14.1",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+              "dev": true,
+              "optional": true
+            },
             "secp256k1": {
               "version": "3.8.0",
               "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
@@ -12033,19 +12371,19 @@
           }
         },
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+          "version": "2.8.5",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
         },
         "html-escaper": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-          "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+          "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
         },
         "http-errors": {
           "version": "1.7.2",
@@ -12165,9 +12503,9 @@
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -12252,9 +12590,9 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "immediate": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-          "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
           "dev": true
         },
         "import-fresh": {
@@ -12293,9 +12631,9 @@
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -12363,22 +12701,22 @@
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "inquirer": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+          "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
           "requires": {
             "ansi-escapes": "^4.2.1",
-            "chalk": "^4.1.0",
+            "chalk": "^2.4.2",
             "cli-cursor": "^3.1.0",
-            "cli-width": "^3.0.0",
+            "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.15",
             "mute-stream": "0.0.8",
-            "run-async": "^2.4.0",
-            "rxjs": "^6.6.0",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.5.3",
             "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0",
+            "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
           },
           "dependencies": {
@@ -12388,21 +12726,18 @@
               "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
             },
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-              "requires": {
-                "@types/color-name": "^1.1.1",
-                "color-convert": "^2.0.1"
-              }
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="
             },
             "chalk": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-              "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "color-convert": {
@@ -12429,9 +12764,9 @@
               "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
             },
             "lodash": {
-              "version": "4.17.19",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-              "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+              "version": "4.17.15",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
             },
             "string-width": {
               "version": "4.2.0",
@@ -12439,32 +12774,25 @@
               "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
               "requires": {
                 "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
+                "is-fullwidth-code-point": "^3.0.0"
               }
             },
             "strip-ansi": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="
             }
           }
         },
         "interpret": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
           "dev": true
         },
         "invariant": {
@@ -12483,9 +12811,9 @@
           "dev": true
         },
         "ipaddr.js": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-          "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
         },
         "is-absolute": {
           "version": "1.0.0",
@@ -12540,9 +12868,9 @@
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
         },
         "is-data-descriptor": {
           "version": "0.1.4",
@@ -12595,10 +12923,13 @@
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-finite": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-          "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-          "dev": true
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "is-fn": {
           "version": "1.0.0",
@@ -12615,9 +12946,9 @@
           }
         },
         "is-function": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-          "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+          "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
         },
         "is-glob": {
           "version": "4.0.1",
@@ -12693,16 +13024,16 @@
           }
         },
         "is-promise": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-          "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
         },
         "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
           "requires": {
-            "has-symbols": "^1.0.1"
+            "has": "^1.0.3"
           }
         },
         "is-regexp": {
@@ -12813,11 +13144,14 @@
           }
         },
         "istanbul-lib-instrument": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-          "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
+          "integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
           "requires": {
             "@babel/core": "^7.7.5",
+            "@babel/parser": "^7.7.5",
+            "@babel/template": "^7.7.4",
+            "@babel/traverse": "^7.7.4",
             "@istanbuljs/schema": "^0.1.2",
             "istanbul-lib-coverage": "^3.0.0",
             "semver": "^6.3.0"
@@ -12845,9 +13179,9 @@
           },
           "dependencies": {
             "make-dir": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-              "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
               "requires": {
                 "semver": "^6.0.0"
               }
@@ -12861,9 +13195,9 @@
               }
             },
             "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
               "requires": {
                 "glob": "^7.1.3"
               }
@@ -12891,9 +13225,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "make-dir": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-              "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
               "requires": {
                 "semver": "^6.0.0"
               }
@@ -12934,9 +13268,9 @@
           }
         },
         "istanbul-reports": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-          "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
           "requires": {
             "html-escaper": "^2.0.0",
             "istanbul-lib-report": "^3.0.0"
@@ -12979,9 +13313,9 @@
           }
         },
         "js-sha3": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
+          "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA="
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -12990,9 +13324,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -13115,13 +13449,15 @@
           "dev": true
         },
         "keccak": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
           "dev": true,
           "requires": {
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
           }
         },
         "keyv": {
@@ -13226,13 +13562,10 @@
           }
         },
         "level-codec": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0"
-          }
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+          "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
+          "dev": true
         },
         "level-concat-iterator": {
           "version": "2.0.1",
@@ -13599,7 +13932,6 @@
             "listr": "^0.14.3",
             "log-symbols": "^3.0.0",
             "micromatch": "^4.0.2",
-            "normalize-path": "^3.0.0",
             "please-upgrade-node": "^3.2.0",
             "stringify-object": "^3.3.0"
           },
@@ -13644,9 +13976,9 @@
               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
             },
             "commander": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-              "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+              "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
             },
             "debug": {
               "version": "4.1.1",
@@ -13860,22 +14192,19 @@
           "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "requires": {
             "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
+            "emojis-list": "^2.0.0",
             "json5": "^1.0.1"
           },
           "dependencies": {
             "json5": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-              "requires": {
-                "minimist": "^1.2.0"
-              }
+              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow=="
             }
           }
         },
@@ -14055,11 +14384,11 @@
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "requires": {
-            "yallist": "^3.0.2"
+            "pseudomap": "^1.0.1"
           }
         },
         "ltgt": {
@@ -14191,12 +14520,10 @@
           },
           "dependencies": {
             "abstract-leveldown": {
-              "version": "6.2.3",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-              "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+              "version": "6.2.2",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
+              "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
               "requires": {
-                "buffer": "^5.5.0",
-                "immediate": "^3.2.3",
                 "level-concat-iterator": "~2.0.0",
                 "level-supports": "~1.0.0",
                 "xtend": "~4.0.0"
@@ -14299,18 +14626,18 @@
               "dev": true
             },
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             },
             "isarray": {
@@ -14459,16 +14786,16 @@
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
         },
         "mime-types": {
-          "version": "2.1.27",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
           "requires": {
-            "mime-db": "1.44.0"
+            "mime-db": "1.43.0"
           }
         },
         "mimic-fn": {
@@ -14508,9 +14835,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.9.0",
@@ -14530,9 +14857,9 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-              "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -14553,9 +14880,9 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-              "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -14568,17 +14895,17 @@
           }
         },
         "minipass-pipeline": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-          "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+          "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
           "requires": {
             "minipass": "^3.0.0"
           },
           "dependencies": {
             "minipass": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-              "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -14635,9 +14962,9 @@
           }
         },
         "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
         },
         "mkdirp-promise": {
           "version": "5.0.1",
@@ -14701,14 +15028,13 @@
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
               "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
               "requires": {
-                "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
               }
             },
             "binary-extensions": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-              "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+              "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
             },
             "braces": {
               "version": "3.0.2",
@@ -14754,7 +15080,6 @@
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
                 "readdirp": "~3.2.0"
               }
             },
@@ -14790,9 +15115,9 @@
               }
             },
             "fsevents": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+              "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
               "optional": true
             },
             "get-caller-file": {
@@ -14814,9 +15139,9 @@
               }
             },
             "glob-parent": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-              "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+              "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
               "requires": {
                 "is-glob": "^4.0.1"
               }
@@ -14884,9 +15209,9 @@
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -15015,9 +15340,9 @@
           "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q="
         },
         "mock-fs": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
-          "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
+          "version": "4.10.4",
+          "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
+          "integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ=="
         },
         "move-concurrently": {
           "version": "1.0.1",
@@ -15033,11 +15358,11 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             }
           }
@@ -15059,9 +15384,9 @@
           "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
         },
         "nan": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         },
         "nano-json-stream-parser": {
           "version": "0.1.2",
@@ -15097,9 +15422,9 @@
           "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
         },
         "neo-async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-          "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
         },
         "next-tick": {
           "version": "1.0.0",
@@ -15114,8 +15439,7 @@
         "node-addon-api": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-          "dev": true
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
         },
         "node-environment-flags": {
           "version": "1.0.6",
@@ -15142,8 +15466,7 @@
         "node-gyp-build": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-          "dev": true
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
         },
         "node-libs-browser": {
           "version": "2.2.1",
@@ -15167,7 +15490,6 @@
             "readable-stream": "^2.3.3",
             "stream-browserify": "^2.0.1",
             "stream-http": "^2.7.2",
-            "string_decoder": "^1.0.0",
             "timers-browserify": "^2.0.4",
             "tty-browserify": "0.0.0",
             "url": "^0.11.0",
@@ -15273,9 +15595,12 @@
           }
         },
         "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
         },
         "normalize-url": {
           "version": "4.5.0",
@@ -15321,9 +15646,9 @@
           }
         },
         "nyc": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-          "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
+          "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
           "requires": {
             "@istanbuljs/load-nyc-config": "^1.0.0",
             "@istanbuljs/schema": "^0.1.2",
@@ -15333,7 +15658,6 @@
             "find-cache-dir": "^3.2.0",
             "find-up": "^4.1.0",
             "foreground-child": "^2.0.0",
-            "get-package-type": "^0.1.0",
             "glob": "^7.1.6",
             "istanbul-lib-coverage": "^3.0.0",
             "istanbul-lib-hook": "^3.0.0",
@@ -15341,9 +15665,10 @@
             "istanbul-lib-processinfo": "^2.0.2",
             "istanbul-lib-report": "^3.0.0",
             "istanbul-lib-source-maps": "^4.0.0",
-            "istanbul-reports": "^3.0.2",
+            "istanbul-reports": "^3.0.0",
+            "js-yaml": "^3.13.1",
             "make-dir": "^3.0.0",
-            "node-preload": "^0.2.1",
+            "node-preload": "^0.2.0",
             "p-map": "^3.0.0",
             "process-on-spawn": "^1.0.0",
             "resolve-from": "^5.0.0",
@@ -15351,6 +15676,7 @@
             "signal-exit": "^3.0.2",
             "spawn-wrap": "^2.0.0",
             "test-exclude": "^6.0.0",
+            "uuid": "^3.3.3",
             "yargs": "^15.0.2"
           },
           "dependencies": {
@@ -15424,17 +15750,17 @@
               }
             },
             "make-dir": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-              "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
               "requires": {
                 "semver": "^6.0.0"
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -15476,9 +15802,9 @@
               "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
             },
             "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
               "requires": {
                 "glob": "^7.1.3"
               }
@@ -15527,9 +15853,9 @@
               "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             },
             "yargs": {
-              "version": "15.4.1",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-              "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+              "version": "15.1.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+              "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
               "requires": {
                 "cliui": "^6.0.0",
                 "decamelize": "^1.2.0",
@@ -15541,13 +15867,13 @@
                 "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.2"
+                "yargs-parser": "^16.1.0"
               }
             },
             "yargs-parser": {
-              "version": "18.1.3",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+              "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
               "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
@@ -15594,19 +15920,15 @@
           }
         },
         "object-inspect": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
         },
         "object-is": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-          "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5"
-          }
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+          "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+          "dev": true
         },
         "object-keys": {
           "version": "0.4.0",
@@ -15725,17 +16047,17 @@
           }
         },
         "onetime": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.1.tgz",
-          "integrity": "sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "requires": {
             "mimic-fn": "^2.1.0"
           }
         },
         "opencollective-postinstall": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-          "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+          "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
         },
         "optionator": {
           "version": "0.8.3",
@@ -16076,9 +16398,9 @@
           }
         },
         "pbkdf2": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-          "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+          "version": "3.0.17",
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+          "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
           "requires": {
             "create-hash": "^1.1.2",
             "create-hmac": "^1.1.4",
@@ -16098,9 +16420,9 @@
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+          "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
         },
         "pify": {
           "version": "4.0.1",
@@ -16147,21 +16469,21 @@
           }
         },
         "portfinder": {
-          "version": "1.0.28",
-          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-          "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+          "version": "1.0.25",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+          "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
           "requires": {
             "async": "^2.6.2",
             "debug": "^3.1.1",
-            "mkdirp": "^0.5.5"
+            "mkdirp": "^0.5.1"
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             }
           }
@@ -16243,12 +16565,12 @@
           }
         },
         "proxy-addr": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-          "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+          "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
           "requires": {
             "forwarded": "~0.1.2",
-            "ipaddr.js": "1.9.1"
+            "ipaddr.js": "1.9.0"
           }
         },
         "prr": {
@@ -16259,13 +16581,12 @@
         "pseudomap": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-          "dev": true
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+          "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
         },
         "public-encrypt": {
           "version": "4.0.3",
@@ -16453,13 +16774,14 @@
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "process-nextick-args": "~2.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
@@ -16516,9 +16838,9 @@
           }
         },
         "regenerate": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
-          "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -16641,9 +16963,9 @@
           }
         },
         "replace-ext": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-          "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
           "dev": true
         },
         "replace-homedir": {
@@ -16658,9 +16980,9 @@
           }
         },
         "request": {
-          "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -16669,7 +16991,7 @@
             "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
             "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
+            "har-validator": "~5.1.0",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
@@ -16679,7 +17001,7 @@
             "performance-now": "^2.1.0",
             "qs": "~6.5.2",
             "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
+            "tough-cookie": "~2.4.3",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
           },
@@ -16708,9 +17030,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -16807,17 +17129,20 @@
           }
         },
         "rlp": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
           "requires": {
             "bn.js": "^4.11.1"
           }
         },
         "run-async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-          "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
         },
         "run-queue": {
           "version": "1.0.3",
@@ -16834,17 +17159,17 @@
           "dev": true
         },
         "rxjs": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
           "requires": {
             "tslib": "^1.9.0"
           }
         },
         "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         },
         "safe-event-emitter": {
           "version": "1.0.1",
@@ -16869,12 +17194,11 @@
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
           "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
+            "ajv": "^6.10.2",
             "ajv-keywords": "^3.4.1"
           }
         },
@@ -16889,10 +17213,9 @@
           }
         },
         "scrypt-js": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-          "dev": true
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
         },
         "scrypt.js": {
           "version": "0.3.0",
@@ -16916,14 +17239,27 @@
           }
         },
         "secp256k1": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
           "dev": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
             "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "2.14.1",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+              "dev": true
+            }
           }
         },
         "seedrandom": {
@@ -16933,11 +17269,11 @@
           "dev": true
         },
         "seek-bzip": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
-          "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+          "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
           "requires": {
-            "commander": "^2.8.1"
+            "commander": "~2.8.1"
           }
         },
         "semaphore": {
@@ -17100,14 +17436,14 @@
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "signal-exit": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "simple-concat": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
         },
         "simple-get": {
           "version": "2.8.1",
@@ -17273,7 +17609,6 @@
             "command-exists": "^1.2.8",
             "commander": "3.0.2",
             "fs-extra": "^0.30.0",
-            "js-sha3": "0.8.0",
             "memorystream": "^0.3.1",
             "require-from-string": "^2.0.0",
             "semver": "^5.5.0",
@@ -17376,17 +17711,17 @@
           },
           "dependencies": {
             "make-dir": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-              "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
               "requires": {
                 "semver": "^6.0.0"
               }
             },
             "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
               "requires": {
                 "glob": "^7.1.3"
               }
@@ -17407,23 +17742,23 @@
           }
         },
         "spdx-correct": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-          "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+          "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-          "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
         },
         "spdx-expression-parse": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -17480,9 +17815,9 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-              "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -17682,8 +18017,7 @@
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
           "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5"
+            "define-properties": "^1.1.3"
           }
         },
         "string.prototype.trimstart": {
@@ -17691,17 +18025,13 @@
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
           "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5"
+            "define-properties": "^1.1.3"
           }
         },
         "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "stringify-object": {
           "version": "3.3.0",
@@ -17757,9 +18087,9 @@
           }
         },
         "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
         },
         "supports-color": {
           "version": "2.0.0",
@@ -17898,9 +18228,9 @@
           "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         },
         "tape": {
-          "version": "4.13.3",
-          "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
-          "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
+          "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
           "dev": true,
           "requires": {
             "deep-equal": "~1.1.1",
@@ -17912,9 +18242,9 @@
             "has": "~1.0.3",
             "inherits": "~2.0.4",
             "is-regex": "~1.0.5",
-            "minimist": "~1.2.5",
+            "minimist": "~1.2.0",
             "object-inspect": "~1.7.0",
-            "resolve": "~1.17.0",
+            "resolve": "~1.14.2",
             "resumer": "~0.0.0",
             "string.prototype.trim": "~1.2.1",
             "through": "~2.3.8"
@@ -17928,6 +18258,12 @@
               "requires": {
                 "has": "^1.0.3"
               }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
             },
             "object-inspect": {
               "version": "1.7.0",
@@ -17952,11 +18288,11 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             }
           }
@@ -18028,11 +18364,10 @@
           }
         },
         "terser": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+          "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
           "requires": {
-            "commander": "^2.20.0",
             "source-map": "~0.6.1",
             "source-map-support": "~0.5.12"
           }
@@ -18237,12 +18572,19 @@
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
         },
         "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            }
           }
         },
         "trim-right": {
@@ -18252,9 +18594,9 @@
           "dev": true
         },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
         },
         "tty-browserify": {
           "version": "0.0.0",
@@ -18270,15 +18612,15 @@
           }
         },
         "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.2.tgz",
+          "integrity": "sha512-+8aPRjmXgf1VqvyxSlBUzKzeYqVS9Ai8vZ28g+mL7dNQl1jlUTCMDZnvNQdAS1xTywMkIXwJsfipsR/6s2+syw==",
           "dev": true
         },
         "tweetnacl-util": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-          "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
+          "integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU=",
           "dev": true
         },
         "type": {
@@ -18348,9 +18690,9 @@
           "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
         },
         "unbzip2-stream": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-          "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+          "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
           "requires": {
             "buffer": "^5.2.1",
             "through": "^2.3.8"
@@ -18589,14 +18931,14 @@
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-compile-cache": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-          "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+          "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
         },
         "v8flags": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
-          "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+          "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
           "dev": true,
           "requires": {
             "homedir-polyfill": "^1.0.1"
@@ -18741,37 +19083,31 @@
           "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
         },
         "watchpack": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-          "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+          "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
           "requires": {
-            "chokidar": "^3.4.1",
             "graceful-fs": "^4.1.2",
-            "neo-async": "^2.5.0",
-            "watchpack-chokidar2": "^2.0.0"
+            "neo-async": "^2.5.0"
           },
           "dependencies": {
             "anymatch": {
               "version": "3.1.1",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
               "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-              "optional": true,
               "requires": {
-                "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
               }
             },
             "binary-extensions": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-              "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-              "optional": true
+              "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
             },
             "braces": {
               "version": "3.0.2",
               "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-              "optional": true,
               "requires": {
                 "fill-range": "^7.0.1"
               }
@@ -18780,7 +19116,6 @@
               "version": "3.4.1",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
               "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
-              "optional": true,
               "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -18788,7 +19123,6 @@
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
                 "readdirp": "~3.4.0"
               }
             },
@@ -18796,7 +19130,6 @@
               "version": "7.0.1",
               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
               "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-              "optional": true,
               "requires": {
                 "to-regex-range": "^5.0.1"
               }
@@ -18811,7 +19144,6 @@
               "version": "5.1.1",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
               "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-              "optional": true,
               "requires": {
                 "is-glob": "^4.0.1"
               }
@@ -18820,7 +19152,6 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
               "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-              "optional": true,
               "requires": {
                 "binary-extensions": "^2.0.0"
               }
@@ -18828,14 +19159,12 @@
             "is-number": {
               "version": "7.0.0",
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-              "optional": true
+              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
             },
             "readdirp": {
               "version": "3.4.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
               "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-              "optional": true,
               "requires": {
                 "picomatch": "^2.2.1"
               }
@@ -18844,7 +19173,6 @@
               "version": "5.0.1",
               "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-              "optional": true,
               "requires": {
                 "is-number": "^7.0.0"
               }
@@ -18855,7 +19183,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
           "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
-          "optional": true,
           "requires": {
             "chokidar": "^2.1.8"
           }
@@ -18876,9 +19203,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "12.12.53",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
-              "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
+              "version": "12.12.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
             }
           }
         },
@@ -18894,9 +19221,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.28",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-              "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+              "version": "10.17.14",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
             }
           }
         },
@@ -18915,9 +19242,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "12.12.53",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
-              "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
+              "version": "12.12.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
             }
           }
         },
@@ -19005,9 +19332,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.28",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-              "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+              "version": "10.17.14",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
             },
             "aes-js": {
               "version": "3.0.0",
@@ -19170,9 +19497,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "12.12.53",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
-              "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
+              "version": "12.12.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
             }
           }
         },
@@ -19240,18 +19567,32 @@
               },
               "dependencies": {
                 "ethereumjs-util": {
-                  "version": "6.2.1",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "keccak": "^2.0.0",
+                    "rlp": "^2.2.3",
+                    "secp256k1": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "keccak": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+                      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.5.0",
+                        "inherits": "^2.0.4",
+                        "nan": "^2.14.0",
+                        "safe-buffer": "^5.2.0"
+                      }
+                    }
                   }
                 }
               }
@@ -19299,18 +19640,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
               }
             },
             "ethereumjs-vm": {
@@ -19346,18 +19687,18 @@
                   },
                   "dependencies": {
                     "ethereumjs-util": {
-                      "version": "5.2.1",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
                       "dev": true,
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
-                        "elliptic": "^6.5.2",
-                        "ethereum-cryptography": "^0.1.3",
                         "ethjs-util": "^0.1.3",
+                        "keccak": "^1.0.2",
                         "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
                       }
                     }
                   }
@@ -19373,18 +19714,32 @@
                   }
                 },
                 "ethereumjs-util": {
-                  "version": "6.2.1",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "keccak": "^2.0.0",
+                    "rlp": "^2.2.3",
+                    "secp256k1": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "keccak": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+                      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.5.0",
+                        "inherits": "^2.0.4",
+                        "nan": "^2.14.0",
+                        "safe-buffer": "^5.2.0"
+                      }
+                    }
                   }
                 }
               }
@@ -19393,6 +19748,12 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "nan": {
+              "version": "2.14.1",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+              "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
               "dev": true
             },
             "readable-stream": {
@@ -19549,14 +19910,14 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+              "version": "6.4.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
             },
             "cacache": {
-              "version": "12.0.4",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-              "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+              "version": "12.0.3",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+              "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
               "requires": {
                 "bluebird": "^3.5.5",
                 "chownr": "^1.1.1",
@@ -19564,7 +19925,6 @@
                 "glob": "^7.1.4",
                 "graceful-fs": "^4.1.15",
                 "infer-owner": "^1.0.3",
-                "lru-cache": "^5.1.1",
                 "mississippi": "^3.0.0",
                 "mkdirp": "^0.5.1",
                 "move-concurrently": "^1.0.1",
@@ -19621,17 +19981,17 @@
               }
             },
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -19694,15 +20054,14 @@
               }
             },
             "terser-webpack-plugin": {
-              "version": "1.4.4",
-              "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-              "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+              "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+              "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
               "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^3.1.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",
@@ -19721,7 +20080,6 @@
           "resolved": "https://registry.npmjs.org/webpack-bundle-size-analyzer/-/webpack-bundle-size-analyzer-3.1.0.tgz",
           "integrity": "sha512-8WlTT6uuCxZgZYNnCB0pRGukWRGH+Owg+HsqQUe1Zexakdno1eDYO+lE7ihBo9G0aCCZCJa8JWjYr9eLYfZrBA==",
           "requires": {
-            "commander": "^2.19.0",
             "filesize": "^3.6.1",
             "humanize": "0.0.9"
           }
@@ -19887,10 +20245,7 @@
             "json5": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-              "requires": {
-                "minimist": "^1.2.0"
-              }
+              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow=="
             },
             "lcid": {
               "version": "2.0.0",
@@ -19938,9 +20293,9 @@
               }
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -20061,9 +20416,9 @@
               }
             },
             "yargs-parser": {
-              "version": "13.1.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-              "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+              "version": "13.1.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
               "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
@@ -20180,19 +20535,19 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "0.0.8"
               }
             }
           }
         },
         "write-file-atomic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
@@ -20243,11 +20598,11 @@
           }
         },
         "xhr-request-promise": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
-          "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
+          "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "requires": {
-            "xhr-request": "^1.1.0"
+            "xhr-request": "^1.0.1"
           }
         },
         "xhr2-cookies": {
@@ -20285,14 +20640,17 @@
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
         "yaml": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-          "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+          "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+          "requires": {
+            "@babel/runtime": "^7.6.3"
+          }
         },
         "yargs": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
-          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
@@ -20307,17 +20665,16 @@
             "string-width": "^1.0.2",
             "which-module": "^1.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "5.0.0-security.0"
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
-          "version": "5.0.0-security.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
-          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "object.assign": "^4.1.0"
+            "camelcase": "^3.0.0"
           }
         },
         "yargs-unparser": {
@@ -20391,14 +20748,14 @@
               }
             },
             "lodash": {
-              "version": "4.17.19",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-              "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+              "version": "4.17.15",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
             },
             "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -20465,9 +20822,9 @@
               "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             },
             "yargs": {
-              "version": "13.3.2",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-              "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+              "version": "13.3.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+              "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
               "requires": {
                 "cliui": "^5.0.0",
                 "find-up": "^3.0.0",
@@ -20478,13 +20835,13 @@
                 "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.2"
+                "yargs-parser": "^13.1.1"
               }
             },
             "yargs-parser": {
-              "version": "13.1.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-              "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+              "version": "13.1.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
               "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
@@ -20507,7 +20864,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
       "optional": true,
       "requires": {
         "aproba": "^1.0.3",
@@ -20573,9 +20929,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -20591,10 +20947,13 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "google-libphonenumber": {
       "version": "3.2.13",
@@ -20624,6 +20983,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -20635,11 +20999,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^6.12.3",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       }
     },
@@ -20687,17 +21051,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
       "optional": true
     },
     "hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -20707,34 +21069,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hdkey": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
-      "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
-      "dev": true,
-      "requires": {
-        "coinstring": "^2.0.0",
-        "secp256k1": "^3.0.1"
-      },
-      "dependencies": {
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        }
       }
     },
     "he": {
@@ -20807,11 +21141,11 @@
       }
     },
     "iconv-lite": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "idna-uts46-hx": {
@@ -20840,10 +21174,20 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "optional": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -20879,25 +21223,24 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true,
       "optional": true
     },
     "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
+        "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
+        "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -20920,9 +21263,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -20942,6 +21285,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
         "has-flag": {
@@ -20977,9 +21326,9 @@
           }
         },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -20996,11 +21345,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
     "io-ts": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.1.tgz",
@@ -21014,12 +21358,8 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-buffer": {
       "version": "2.0.4",
@@ -21027,9 +21367,9 @@
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -21063,9 +21403,9 @@
       }
     },
     "is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -21095,6 +21435,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.5",
@@ -21127,11 +21473,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -21146,6 +21487,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -21166,21 +21508,20 @@
       }
     },
     "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "dev": true,
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -21307,18 +21648,28 @@
       }
     },
     "keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
       "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
+        "bindings": "^1.5.0",
+        "inherits": "^2.0.4",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         }
       }
     },
@@ -21352,31 +21703,17 @@
         "json-buffer": "3.0.0"
       }
     },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
+      "dev": true
     },
     "level-errors": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "dev": true,
       "requires": {
         "errno": "~0.1.1"
       }
@@ -21385,6 +21722,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "level-errors": "^1.0.3",
@@ -21395,12 +21733,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -21411,7 +21751,8 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         }
       }
     },
@@ -21419,6 +21760,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+      "dev": true,
       "requires": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
@@ -21427,17 +21769,20 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -21448,12 +21793,14 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "xtend": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
           "requires": {
             "object-keys": "~0.4.0"
           }
@@ -21464,6 +21811,7 @@
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "dev": true,
       "requires": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -21477,7 +21825,8 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
         }
       }
     },
@@ -21491,22 +21840,9 @@
         "type-check": "~0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      }
-    },
     "loady": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
-      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
+      "resolved": "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
     },
     "locate-path": {
       "version": "3.0.0",
@@ -21518,14 +21854,15 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=",
+      "dev": true
     },
     "lodash.values": {
       "version": "4.3.0",
@@ -21558,7 +21895,8 @@
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -21599,6 +21937,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "dev": true,
       "requires": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -21612,6 +21951,7 @@
           "version": "2.7.2",
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "dev": true,
           "requires": {
             "xtend": "~4.0.0"
           }
@@ -21619,14 +21959,10 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
-    },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -21637,6 +21973,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
       "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+      "dev": true,
       "requires": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -21651,33 +21988,34 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
         },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
           }
         }
       }
@@ -21702,16 +22040,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -21773,17 +22111,24 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
       "dev": true,
       "optional": true
     },
@@ -21796,9 +22141,9 @@
       }
     },
     "mocha": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
-      "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
@@ -21812,7 +22157,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.4",
+        "mkdirp": "0.5.1",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.5",
         "object.assign": "4.1.0",
@@ -21820,8 +22165,8 @@
         "supports-color": "6.0.0",
         "which": "1.3.1",
         "wide-align": "1.1.3",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
@@ -21846,23 +22191,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -21879,9 +22207,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
-      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+      "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -21937,9 +22265,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -21959,6 +22287,34 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "optional": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "optional": true
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -21976,9 +22332,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
+      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -22003,15 +22359,16 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
     },
     "node-gyp-build": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-      "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-hid": {
       "version": "0.7.9",
@@ -22023,6 +22380,54 @@
         "bindings": "^1.5.0",
         "nan": "^2.13.2",
         "prebuild-install": "^5.3.0"
+      },
+      "dependencies": {
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "nofilter": {
@@ -22037,15 +22442,14 @@
       "dev": true,
       "optional": true
     },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "optional": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-url": {
@@ -22053,11 +22457,36 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "optional": true,
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "optional": true
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "optional": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -22111,9 +22540,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        }
       }
     },
     "object-keys": {
@@ -22166,12 +22617,17 @@
       }
     },
     "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "openzeppelin-solidity": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
     },
     "optionator": {
       "version": "0.8.3",
@@ -22190,22 +22646,22 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "optional": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -22218,9 +22674,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -22256,12 +22712,13 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "requires": {
-        "asn1.js": "^5.2.0",
+        "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
@@ -22271,14 +22728,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
       "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
     },
     "parseurl": {
       "version": "1.3.3",
@@ -22304,22 +22753,13 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -22327,9 +22767,9 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pbkdf2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -22373,16 +22813,16 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
-      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
       "dev": true,
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
+        "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^2.7.0",
@@ -22503,12 +22943,13 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -22538,9 +22979,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
       "version": "5.1.1",
@@ -22583,23 +23024,12 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
@@ -22608,58 +23038,31 @@
         "strip-json-comments": "~2.0.1"
       }
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
     "regenerate": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
-      "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -22683,6 +23086,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -22730,9 +23134,9 @@
       }
     },
     "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -22741,7 +23145,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -22751,15 +23155,15 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
     },
@@ -22767,11 +23171,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -22782,6 +23181,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -22813,6 +23213,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
       "requires": {
         "through": "~2.3.4"
       }
@@ -22835,36 +23236,41 @@
       }
     },
     "rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+      "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
       "requires": {
         "bn.js": "^4.11.1"
       }
     },
     "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
     },
     "rustbn.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+      "dev": true
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safe-event-emitter": {
       "version": "1.0.1",
@@ -22880,10 +23286,16 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "optional": true
+    },
     "scrypt-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "scrypt-shim": {
       "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
@@ -22906,20 +23318,18 @@
       "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
     },
     "secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "requires": {
-        "elliptic": "^6.5.2",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
-        }
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "seek-bzip": {
@@ -22940,7 +23350,8 @@
     "semaphore": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "dev": true
     },
     "semaphore-async-await": {
       "version": "1.5.1",
@@ -23015,9 +23426,9 @@
       "dev": true
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -23031,6 +23442,23 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
+      "integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
+      "dev": true,
+      "requires": {
+        "nan": "2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true
+        }
       }
     },
     "shebang-command": {
@@ -23049,14 +23477,14 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-get": {
       "version": "2.8.1",
@@ -23093,122 +23521,6 @@
         }
       }
     },
-    "solc": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.26.tgz",
-      "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
-      "requires": {
-        "fs-extra": "^0.30.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "get-caller-file": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
-        "yargs": {
-          "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
-          }
-        }
-      }
-    },
-    "solidity-bytes-utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/solidity-bytes-utils/-/solidity-bytes-utils-0.0.7.tgz",
-      "integrity": "sha512-NdzNDmzpd45MiEmYS5MVW1O0ovjneyXpPV5iWt05juA77KFQqO2axQOdkMGvKtA69nxobKQU9BakopeT48bWRQ==",
-      "requires": {
-        "truffle-hdwallet-provider": "0.0.3"
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -23223,34 +23535,6 @@
       "requires": {
         "source-map": "^0.5.6"
       }
-    },
-    "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "spinnies": {
       "version": "0.4.3",
@@ -23322,36 +23606,44 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
       "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1"
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "function-bind": "^1.1.1"
       }
     },
-    "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "strip-ansi": {
@@ -23360,14 +23652,6 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
       }
     },
     "strip-dirs": {
@@ -23400,13 +23684,13 @@
       }
     },
     "swarm-js": {
-      "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
-      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
-      "dev": true,
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+      "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
       "requires": {
         "bluebird": "^3.5.0",
         "buffer": "^5.0.5",
+        "decompress": "^4.0.0",
         "eth-lib": "^0.1.26",
         "fs-extra": "^4.0.2",
         "got": "^7.1.0",
@@ -23415,34 +23699,18 @@
         "mock-fs": "^4.1.0",
         "setimmediate": "^1.0.5",
         "tar": "^4.0.2",
-        "xhr-request": "^1.0.1"
+        "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
-        "eth-lib": {
-          "version": "0.1.29",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-          "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "nano-json-stream-parser": "^0.1.2",
-            "servify": "^0.1.12",
-            "ws": "^3.0.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "got": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "dev": true,
           "requires": {
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
@@ -23463,39 +23731,24 @@
         "p-cancelable": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "dev": true
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
         },
         "prepend-http": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
-          }
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
           }
         }
       }
@@ -23516,12 +23769,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -23553,9 +23800,10 @@
       }
     },
     "tape": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
-      "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.2.tgz",
+      "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
+      "dev": true,
       "requires": {
         "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
@@ -23566,12 +23814,23 @@
         "has": "~1.0.3",
         "inherits": "~2.0.4",
         "is-regex": "~1.0.5",
-        "minimist": "~1.2.5",
+        "minimist": "~1.2.0",
         "object-inspect": "~1.7.0",
-        "resolve": "~1.17.0",
+        "resolve": "~1.15.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.2.1",
         "through": "~2.3.8"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "tar": {
@@ -23589,9 +23848,9 @@
       }
     },
     "tar-fs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -23599,20 +23858,71 @@
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tar-stream": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+          "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bl": "^4.0.1",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        }
       }
     },
     "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
-      "dev": true,
-      "optional": true,
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
-        "bl": "^4.0.1",
-        "end-of-stream": "^1.4.1",
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
         "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
       }
     },
     "text-table": {
@@ -23634,38 +23944,6 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "timed-out": {
@@ -23683,6 +23961,13 @@
         "create-hmac": "^1.1.7",
         "elliptic": "^6.4.0",
         "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+        }
       }
     },
     "tmp": {
@@ -23716,12 +24001,19 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "trim-right": {
@@ -23731,12 +24023,12 @@
       "dev": true
     },
     "truffle-flattener": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.4.tgz",
-      "integrity": "sha512-S/WmvubzlUj1mn56wEI6yo1bmPpKDNdEe5rtyVC1C5iNfZWobD/V69pAYI15IBDJrDqUyh+iXgpTkzov50zpQw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.5.0.tgz",
+      "integrity": "sha512-vmzWG/L5OXoNruMV6u2l2IaheI091e+t+fFCOR9sl46EE3epkSRIwGCmIP/EYDtPsFBIG7e6exttC9/GlfmxEQ==",
       "requires": {
         "@resolver-engine/imports-fs": "^0.2.2",
-        "@solidity-parser/parser": "^0.6.0",
+        "@solidity-parser/parser": "^0.8.0",
         "find-up": "^2.1.0",
         "mkdirp": "^1.0.4",
         "tsort": "0.0.1"
@@ -23787,74 +24079,6 @@
         }
       }
     },
-    "truffle-hdwallet-provider": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-0.0.3.tgz",
-      "integrity": "sha1-Dh3gIQS3PTh14c9wkzBbTqii2EM=",
-      "requires": {
-        "bip39": "^2.2.0",
-        "ethereumjs-wallet": "^0.6.0",
-        "web3": "^0.18.2",
-        "web3-provider-engine": "^8.4.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-        },
-        "utf8": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
-        },
-        "web3": {
-          "version": "0.18.4",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-          "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
-          }
-        },
-        "web3-provider-engine": {
-          "version": "8.6.1",
-          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
-          "integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
-          "requires": {
-            "async": "^2.1.2",
-            "clone": "^2.0.0",
-            "ethereumjs-block": "^1.2.2",
-            "ethereumjs-tx": "^1.2.0",
-            "ethereumjs-util": "^5.0.1",
-            "ethereumjs-vm": "^2.0.2",
-            "isomorphic-fetch": "^2.2.0",
-            "request": "^2.67.0",
-            "semaphore": "^1.0.3",
-            "solc": "^0.4.2",
-            "tape": "^4.4.0",
-            "web3": "^0.16.0",
-            "xhr": "^2.2.0",
-            "xtend": "^4.0.1"
-          },
-          "dependencies": {
-            "web3": {
-              "version": "0.16.0",
-              "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-              "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-              "requires": {
-                "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-                "crypto-js": "^3.1.4",
-                "utf8": "^2.1.1",
-                "xmlhttprequest": "*"
-              }
-            }
-          }
-        }
-      }
-    },
     "ts-node": {
       "version": "8.10.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
@@ -23889,9 +24113,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tsort": {
       "version": "0.0.1",
@@ -24003,7 +24227,8 @@
     "unorm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -24011,9 +24236,9 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -24048,6 +24273,16 @@
         "prebuild-install": "^5.3.3"
       },
       "dependencies": {
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
         "nan": {
           "version": "2.13.2",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
@@ -24055,14 +24290,6 @@
           "dev": true,
           "optional": true
         }
-      }
-    },
-    "utf-8-validate": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
-      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
-      "requires": {
-        "node-gyp-build": "~3.7.0"
       }
     },
     "utf8": {
@@ -24081,14 +24308,14 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
     "valid-url": {
@@ -24096,15 +24323,6 @@
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
       "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
     },
     "varint": {
       "version": "5.0.0",
@@ -24140,6 +24358,291 @@
         "web3-net": "1.2.11",
         "web3-shh": "1.2.11",
         "web3-utils": "1.2.11"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        },
+        "web3-core": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
+          "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-core-requestmanager": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+          "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
+          "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-promievent": "1.2.11",
+            "web3-core-subscriptions": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
+          "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
+          "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11",
+            "web3-providers-http": "1.2.11",
+            "web3-providers-ipc": "1.2.11",
+            "web3-providers-ws": "1.2.11"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
+          "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
+          "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.11",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-core-subscriptions": "1.2.11",
+            "web3-eth-abi": "1.2.11",
+            "web3-eth-accounts": "1.2.11",
+            "web3-eth-contract": "1.2.11",
+            "web3-eth-ens": "1.2.11",
+            "web3-eth-iban": "1.2.11",
+            "web3-eth-personal": "1.2.11",
+            "web3-net": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
+          "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.0.0-beta.153",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
+          "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
+          "dev": true,
+          "requires": {
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.11",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
+          "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.11",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-core-promievent": "1.2.11",
+            "web3-core-subscriptions": "1.2.11",
+            "web3-eth-abi": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
+          "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
+          "dev": true,
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.11",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-promievent": "1.2.11",
+            "web3-eth-abi": "1.2.11",
+            "web3-eth-contract": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+          "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
+          "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "web3-core": "1.2.11",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-net": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
+          "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
+          "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.11",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
+          "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
+          "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11",
+            "websocket": "^1.0.31"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+          "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-bzz": {
@@ -24154,348 +24657,850 @@
         "underscore": "1.9.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ==",
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+          "dev": true
+        },
+        "swarm-js": {
+          "version": "0.1.40",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+          "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request": "^1.0.1"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
         }
       }
     },
     "web3-core": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
-      "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
+      "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
       "requires": {
-        "@types/bn.js": "^4.11.5",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-requestmanager": "1.2.11",
-        "web3-utils": "1.2.11"
+        "@types/bn.js": "^4.11.4",
+        "@types/node": "^12.6.1",
+        "web3-core-helpers": "1.2.2",
+        "web3-core-method": "1.2.2",
+        "web3-core-requestmanager": "1.2.2",
+        "web3-utils": "1.2.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ==",
-          "dev": true
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
-      "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
+      "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-eth-iban": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-method": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
-      "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
+      "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
       "requires": {
-        "@ethersproject/transactions": "^5.0.0-beta.135",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core-helpers": "1.2.2",
+        "web3-core-promievent": "1.2.2",
+        "web3-core-subscriptions": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-promievent": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
-      "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
+      "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
       "requires": {
-        "eventemitter3": "4.0.4"
+        "any-promise": "1.3.0",
+        "eventemitter3": "3.1.2"
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
-      "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
+      "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "web3-providers-http": "1.2.11",
-        "web3-providers-ipc": "1.2.11",
-        "web3-providers-ws": "1.2.11"
+        "web3-core-helpers": "1.2.2",
+        "web3-providers-http": "1.2.2",
+        "web3-providers-ipc": "1.2.2",
+        "web3-providers-ws": "1.2.2"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
-      "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
+      "integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
       "requires": {
-        "eventemitter3": "4.0.4",
+        "eventemitter3": "3.1.2",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11"
+        "web3-core-helpers": "1.2.2"
       }
     },
     "web3-eth": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
-      "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
+      "integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-eth-accounts": "1.2.11",
-        "web3-eth-contract": "1.2.11",
-        "web3-eth-ens": "1.2.11",
-        "web3-eth-iban": "1.2.11",
-        "web3-eth-personal": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.2.2",
+        "web3-core-helpers": "1.2.2",
+        "web3-core-method": "1.2.2",
+        "web3-core-subscriptions": "1.2.2",
+        "web3-eth-abi": "1.2.2",
+        "web3-eth-accounts": "1.2.2",
+        "web3-eth-contract": "1.2.2",
+        "web3-eth-ens": "1.2.2",
+        "web3-eth-iban": "1.2.2",
+        "web3-eth-personal": "1.2.2",
+        "web3-net": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-abi": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
-      "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.2.tgz",
+      "integrity": "sha512-Yn/ZMgoOLxhTVxIYtPJ0eS6pnAnkTAaJgUJh1JhZS4ekzgswMfEYXOwpMaD5eiqPJLpuxmZFnXnBZlnQ1JMXsw==",
       "requires": {
-        "@ethersproject/abi": "5.0.0-beta.153",
+        "ethers": "4.0.0-beta.3",
         "underscore": "1.9.1",
-        "web3-utils": "1.2.11"
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ethers": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-accounts": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
-      "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
+      "integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
       "requires": {
+        "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
+        "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
-        "scrypt-js": "^3.0.1",
+        "scrypt-shim": "github:web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.2.2",
+        "web3-core-helpers": "1.2.2",
+        "web3-core-method": "1.2.2",
+        "web3-utils": "1.2.2"
       },
       "dependencies": {
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-          "dev": true,
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
           "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
           }
         },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-eth-contract": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
-      "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
+      "integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
       "requires": {
-        "@types/bn.js": "^4.11.5",
+        "@types/bn.js": "^4.11.4",
         "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.2.2",
+        "web3-core-helpers": "1.2.2",
+        "web3-core-method": "1.2.2",
+        "web3-core-promievent": "1.2.2",
+        "web3-core-subscriptions": "1.2.2",
+        "web3-eth-abi": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-ens": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
-      "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
+      "integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
       "requires": {
-        "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-eth-contract": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.2.2",
+        "web3-core-helpers": "1.2.2",
+        "web3-core-promievent": "1.2.2",
+        "web3-eth-abi": "1.2.2",
+        "web3-eth-contract": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-iban": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
-      "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
+      "integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
       "requires": {
-        "bn.js": "^4.11.9",
-        "web3-utils": "1.2.11"
+        "bn.js": "4.11.8",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-personal": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
-      "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
+      "integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
       "requires": {
-        "@types/node": "^12.12.6",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-utils": "1.2.11"
+        "@types/node": "^12.6.1",
+        "web3-core": "1.2.2",
+        "web3-core-helpers": "1.2.2",
+        "web3-core-method": "1.2.2",
+        "web3-net": "1.2.2",
+        "web3-utils": "1.2.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ==",
-          "dev": true
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-net": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
-      "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
+      "integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
       "requires": {
-        "web3-core": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.2.2",
+        "web3-core-method": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-provider-engine": {
-      "version": "14.0.6",
-      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.0.6.tgz",
-      "integrity": "sha512-tr5cGSyxfSC/JqiUpBlJtfZpwQf1yAA8L/zy1C6fDFm0ntR974pobJ4v4676atpZne4Ze5VFy3kPPahHe9gQiQ==",
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-15.0.12.tgz",
+      "integrity": "sha512-/OfhQalKPND1iB5ggvGuYF0+SIb2Qj5OFTrT2VrZWP79UhMTdP7T+L2FtblmRdCeOetoAzZHdBaIwLOZsmIX+w==",
       "dev": true,
       "requires": {
         "async": "^2.5.0",
         "backoff": "^2.5.0",
         "clone": "^2.0.0",
         "cross-fetch": "^2.1.0",
-        "eth-block-tracker": "^3.0.0",
-        "eth-json-rpc-infura": "^3.1.0",
+        "eth-block-tracker": "^4.4.2",
+        "eth-json-rpc-errors": "^2.0.2",
+        "eth-json-rpc-filters": "^4.1.1",
+        "eth-json-rpc-infura": "^4.0.1",
+        "eth-json-rpc-middleware": "^4.1.5",
         "eth-sig-util": "^1.4.2",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",
         "ethereumjs-util": "^5.1.5",
         "ethereumjs-vm": "^2.3.4",
-        "json-rpc-error": "^2.0.0",
         "json-stable-stringify": "^1.0.1",
         "promise-to-callback": "^1.0.0",
         "readable-stream": "^2.2.9",
-        "request": "^2.67.0",
+        "request": "^2.85.0",
         "semaphore": "^1.0.3",
-        "tape": "^4.4.0",
         "ws": "^5.1.1",
         "xhr": "^2.2.0",
         "xtend": "^4.0.1"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+        "eth-block-tracker": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-4.4.3.tgz",
+          "integrity": "sha512-A8tG4Z4iNg4mw5tP1Vung9N9IjgMNqpiMoJ/FouSFwNCGHv2X0mmOYwtQOJzki6XN7r7Tyo01S29p7b224I4jw==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "@babel/plugin-transform-runtime": "^7.5.5",
+            "@babel/runtime": "^7.5.5",
+            "eth-query": "^2.1.0",
+            "json-rpc-random-id": "^1.0.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "eth-json-rpc-infura": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.2.tgz",
+          "integrity": "sha512-dvgOrci9lZqpjpp0hoC3Zfedhg3aIpLFVDH0TdlKxRlkhR75hTrKTwxghDrQwE0bn3eKrC8RsN1m/JdnIWltpw==",
+          "dev": true,
+          "requires": {
+            "cross-fetch": "^2.1.1",
+            "eth-json-rpc-errors": "^1.0.1",
+            "eth-json-rpc-middleware": "^4.1.4",
+            "json-rpc-engine": "^5.1.3"
+          },
+          "dependencies": {
+            "eth-json-rpc-errors": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+              "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+              "dev": true,
+              "requires": {
+                "fast-safe-stringify": "^2.0.6"
+              }
+            }
+          }
+        },
+        "eth-json-rpc-middleware": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz",
+          "integrity": "sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==",
+          "dev": true,
+          "requires": {
+            "btoa": "^1.2.1",
+            "clone": "^2.1.1",
+            "eth-json-rpc-errors": "^1.0.1",
+            "eth-query": "^2.1.2",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.7",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.6.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^5.1.3",
+            "json-stable-stringify": "^1.0.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          },
+          "dependencies": {
+            "eth-json-rpc-errors": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+              "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+              "dev": true,
+              "requires": {
+                "fast-safe-stringify": "^2.0.6"
+              }
+            }
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+          "dev": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "dev": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "json-rpc-engine": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.3.0.tgz",
+          "integrity": "sha512-+diJ9s8rxB+fbJhT7ZEf8r8spaLRignLd8jTgQ/h5JSGppAHGtNMZtCoabipCaleR1B3GTGxbXBOqhaJSGmPGQ==",
+          "dev": true,
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         }
       }
     },
     "web3-providers-http": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
-      "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
+      "integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
       "requires": {
-        "web3-core-helpers": "1.2.11",
+        "web3-core-helpers": "1.2.2",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
-      "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
+      "integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
       "requires": {
         "oboe": "2.1.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11"
+        "web3-core-helpers": "1.2.2"
       }
     },
     "web3-providers-ws": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
-      "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
+      "integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
       "requires": {
-        "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "websocket": "^1.0.31"
+        "web3-core-helpers": "1.2.2",
+        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -24508,40 +25513,232 @@
         "web3-core-method": "1.2.11",
         "web3-core-subscriptions": "1.2.11",
         "web3-net": "1.2.11"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+          "dev": true
+        },
+        "web3-core": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
+          "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-core-requestmanager": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+          "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
+          "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11",
+            "web3-core-promievent": "1.2.11",
+            "web3-core-subscriptions": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
+          "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
+          "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11",
+            "web3-providers-http": "1.2.11",
+            "web3-providers-ipc": "1.2.11",
+            "web3-providers-ws": "1.2.11"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
+          "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+          "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
+          "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.11",
+            "web3-core-method": "1.2.11",
+            "web3-utils": "1.2.11"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
+          "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.11",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
+          "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
+          "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.11",
+            "websocket": "^1.0.31"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+          "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
-      "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+      "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
       "requires": {
-        "bn.js": "^4.11.9",
-        "eth-lib": "0.2.8",
+        "bn.js": "4.11.8",
+        "eth-lib": "0.2.7",
         "ethereum-bloom-filters": "^1.0.6",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
         "underscore": "1.9.1",
         "utf8": "3.0.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        }
       }
     },
     "websocket": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
-      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
+      "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
       "requires": {
-        "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
         "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
         "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
         "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",
@@ -24579,11 +25776,6 @@
         "bs58check": "<3.0.0"
       }
     },
-    "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -24604,11 +25796,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -24650,12 +25837,20 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "dev": true,
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "xhr": {
@@ -24684,17 +25879,12 @@
       }
     },
     "xhr-request-promise": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
-      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
+      "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
       "requires": {
-        "xhr-request": "^1.1.0"
+        "xhr-request": "^1.0.1"
       }
-    },
-    "xhr2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.0.tgz",
-      "integrity": "sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA=="
     },
     "xhr2-cookies": {
       "version": "1.1.0",
@@ -24730,9 +25920,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "requires": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -24743,18 +25933,13 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "yargs-parser": "^13.1.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -24782,9 +25967,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@keep-network/keep-ecdsa": ">1.2.0-rc <1.2.0",
     "@keep-network/tbtc": ">1.1.0-rc <1.1.0",
     "bcoin": "git+https://github.com/keep-network/bcoin.git#355c21aec91128362668162fe5a309dbc0c59c75",
+    "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
     "bufio": "^1.0.6",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
     "web3-utils": "^1.2.8"
@@ -42,6 +43,7 @@
     "web3-provider-engine": "^15.0.7"
   },
   "devDependencies": {
+    "web3-provider-engine": "^15.0.7",
     "@0x/subproviders": "^6.0.8",
     "web3": "^1.2.11",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
   "license": "MIT",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">1.2.0-rc <1.2.0",
-    "@keep-network/tbtc": ">1.1.0-rc <1.1.0",
+    "@keep-network/keep-ecdsa": "1.2.1",
+    "@keep-network/tbtc": "1.1.0",
     "bcoin": "git+https://github.com/keep-network/bcoin.git#355c21aec91128362668162fe5a309dbc0c59c75",
     "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
     "bufio": "^1.0.6",

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -1,4 +1,4 @@
-/** @typedef { import("web3-eth-contract").Contract } EthereumContract */
+/** @typedef { import("./EthereumHelpers.js").Contract } EthereumContract */
 
 import secp256k1 from "bcrypto/lib/secp256k1-browser.js"
 import KeyRing from "bcoin/lib/primitives/keyring.js"

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,8 +1,8 @@
 import web3Utils from "web3-utils"
-/** @typedef { import("web3-eth-contract").Contract } Contract */
 /** @typedef { import("bn.js") } BN */
 
 import EthereumHelpers from "./EthereumHelpers.js"
+/** @typedef { import("./EthereumHelpers.js").Contract } Contract */
 /** @typedef { import("./EthereumHelpers.js").TruffleArtifact } TruffleArtifact */
 /** @typedef { import("./TBTC.js").TBTCConfig } TBTCConfig */
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -393,7 +393,10 @@ export default class Deposit {
    * @param {string} tdtId
    */
   static async forTDT(factory, tdtId) {
-    return this.forAddress(factory, "0x" + toBN(tdtId).toString("hex"))
+    return this.forAddress(
+      factory,
+      factory.config.web3.utils.padLeft("0x" + toBN(tdtId).toString("hex"), 40)
+    )
   }
 
   /**

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -55,6 +55,17 @@ export const DepositStates = {
   LIQUIDATION_IN_PROGRESS: 10,
   LIQUIDATED: 11
 }
+/**
+ * Returns the state name of the given numeric state id.
+ * @param {number} stateId The numeric state id, as defined on chain by the
+ *        deposit `DepositStates` library enum.
+ * @return {string | null} The state name, as defined by the tbtc.js
+ *         `DepositStates` enum.
+ */
+function nameOfState(stateId) {
+  // Find the right id, then take that entry's name.
+  return Object.entries(DepositStates).filter(([_, id]) => id == stateId)[0][0]
+}
 
 export class DepositFactory {
   /**
@@ -80,6 +91,7 @@ export class DepositFactory {
     this.config = config
 
     this.State = DepositStates
+    this.stateById = nameOfState
   }
 
   /**

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1415,9 +1415,9 @@ export default class Deposit {
   /**
    * Notify the contract that the signers have failed to produce a redemption proof.
    */
-  async notifyRedemptionProofTimeout() {
+  async notifyRedemptionProofTimedOut() {
     await EthereumHelpers.sendSafely(
-      this.contract.methods.notifyRedemptionProofTimdOout()
+      this.contract.methods.notifyRedemptionProofTimedOut()
     )
   }
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1323,7 +1323,7 @@ export default class Deposit {
   }
 
   /**
-   * Notify the contract that the deposit is severely undercollateralised,
+   * Notify the contract that the deposit is severely undercollateralized,
    * and begin liquidation of the signer bonds.
    *
    * The bonds are auctioned in a falling-price auction. The value of
@@ -1388,15 +1388,6 @@ export default class Deposit {
   async notifyFundingTimedOut() {
     await EthereumHelpers.sendSafely(
       this.contract.methods.notifyFundingTimedOut()
-    )
-  }
-
-  /**
-   * Notifies the contract that the courtesy period has elapsed.
-   */
-  async notifyCourtesyTimedOut() {
-    await EthereumHelpers.sendSafely(
-      this.contract.methods.notifyCourtesyTimedOut()
     )
   }
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -149,6 +149,18 @@ export class DepositFactory {
   }
 
   /**
+   * Looks up an existing deposit corresponding to the given TDT id, and
+   * returns a tbtc.js Deposit wrapper for it.
+   *
+   * @param {string} tdtId The TDT id of the deposit's tBTC Deposit Token.
+   *
+   * @return {Promise<Deposit>} The deposit at the given address.
+   */
+  async withTdtId(tdtId) {
+    return await Deposit.forTDT(this, tdtId)
+  }
+
+  /**
    * @private
    *
    * Helper to ensure that the contract is defined before returning it. Throws

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -121,6 +121,30 @@ function getEvent(sourceContract, eventName, filter) {
 }
 
 /**
+ * Looks up all existing events named `eventName` on `sourceContract`, searching
+ * past blocks and then returning them. Respects additional filtering rules set
+ * in the passed `filter` object, if available. Does not wait for any new
+ * events.
+ *
+ * @param {Contract} sourceContract The web3 Contract that emits the event.
+ * @param {string} eventName The name of the event to wait on.
+ * @param {any} [filter] An additional filter to apply to the event being
+ *        searched for.
+ *
+ * @return {Promise<any[]>} A promise that will be fulfilled by the list of
+ *         event objects once they are found.
+ */
+async function getExistingEvents(sourceContract, eventName, filter) {
+  const events = await sourceContract.getPastEvents(eventName, {
+    fromBlock: 0,
+    toBlock: "latest",
+    filter
+  })
+
+  return events
+}
+
+/**
  * Looks up an existing event named `eventName` on `sourceContract`, searching
  * past blocks for it and then returning it. Respects additional filtering rules
  * set in the passed `filter` object, if available. Does not wait for any new
@@ -135,13 +159,7 @@ function getEvent(sourceContract, eventName, filter) {
  *         once it is found.
  */
 async function getExistingEvent(sourceContract, eventName, filter) {
-  const events = await sourceContract.getPastEvents(eventName, {
-    fromBlock: 0,
-    toBlock: "latest",
-    filter
-  })
-
-  return events[0]
+  return (await getExistingEvents(sourceContract, eventName, filter))[0]
 }
 
 /**
@@ -281,7 +299,8 @@ async function callWithRetry(
  *         with default `from` and revert handling set.
  */
 function buildContract(web3, contractABI, address) {
-  const contract = new web3.eth.Contract(contractABI)
+  /** @type {Contract} */
+  const contract = /** @type {any} */ (new web3.eth.Contract(contractABI))
   if (address) {
     contract.options.address = address
   }
@@ -320,6 +339,7 @@ function getDeployedContract(artifact, web3, networkId) {
 export default {
   isMainnet,
   getEvent,
+  getExistingEvents,
   getExistingEvent,
   readEventFromTransaction,
   bytesToRaw,

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -159,7 +159,9 @@ async function getExistingEvents(sourceContract, eventName, filter) {
  *         once it is found.
  */
 async function getExistingEvent(sourceContract, eventName, filter) {
-  return (await getExistingEvents(sourceContract, eventName, filter))[0]
+  return (await getExistingEvents(sourceContract, eventName, filter)).slice(
+    -1
+  )[0]
 }
 
 /**

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -86,7 +86,7 @@ function readEventFromTransaction(
  *
  * @param {Contract} sourceContract The web3 Contract that emits the event.
  * @param {string} eventName The name of the event to wait on.
- * @param {object} [filter] An additional filter to apply to the event being
+ * @param {any} [filter] An additional filter to apply to the event being
  *        searched for.
  *
  * @return {Promise<any>} A promise that will be fulfilled by the event
@@ -128,7 +128,7 @@ function getEvent(sourceContract, eventName, filter) {
  *
  * @param {Contract} sourceContract The web3 Contract that emits the event.
  * @param {string} eventName The name of the event to wait on.
- * @param {object} [filter] An additional filter to apply to the event being
+ * @param {any} [filter] An additional filter to apply to the event being
  *        searched for.
  *
  * @return {Promise<any>} A promise that will be fulfilled by the event object


### PR DESCRIPTION
'Bout to slice and dice this sucka.

```
Supported flags:
    --debug
        Enable debug output.

    --rpc <rpc-url>
        Set RPC URL to the specified value.

    --mnemonic <mnemonic>
        Use the specified for the operating account. Also supports private key
        strings, since the underlying provider accepts these.

    --account <account>
        Use the specified account for all transactions. If --mnemonic is
        specified, it must be able to sign for this account in order for
        mutating transactions to be sent to the Ethereum chain. If this is
        left off, the first account for the private key is used.

Supported commands:
    deposit new [--no-mint] <lot-size-satoshis>
        Initiates a deposit funding flow. Takes the lot size in satoshis.
        Will prompt with a Bitcoin address when funding needs to be
        submitted. When the flow completes, outputs the deposit as a single
        tab-delimited line with the deposit address, current deposit state,
        the deposit lot size in satoshis, and, when applicable, the minted
        amount of TBTC.

        --no-mint
            Specifies not to mint TBTC once the deposit is qualified.

    deposit list [--vending-machine] [--address <address>]
        With no options, lists the deposits currently owned by the web3
        account address. Deposits are output as tab-delimited lines that
        include the deposit address, current deposit state, and deposit
        lot size in satoshis.

        --vending-machine
            Lists the deposits currently owned by the vending machine.

        --address <address>
            Lists the deposits currently owned by the specified address.

    deposit <address> [<resume|redeem|liquidate|withdraw>]
        Operations on a particular address. If no command is provided,
        outputs the deposit as a single tab-delimited line with the deposit
        address, current deposit state, and deposit lot size in satoshis.

        resume [--funding|--redemption] [--no-mint]
            Resumes a funding or redemption flow, depending on the deposit's
            current state. When the flow completes, outputs the deposit as a
            single tab-delimited line with the deposit address, current
            deposit state, and deposit lot size in satoshis.

            --funding
                Only resumes the funding flow and outputs the final deposit
                state; if the deposit is not mid-funding, does not resume and
                outputs an error.

                --no-mint
                    When resuming a funding flow, if the deposit is not already
                    mid-minting, specifies not to mint TBTC once the deposit is
                    qualified.

            --redemption
                Only resumes a flow if it is a redemption flow and outputs
                the final deposit state; if the deposit is not mid-redemption,
                does not resume and outputs an error.

        redeem <bitcoin-address>
            Initiates a deposit redemption flow that will redeem the deposit's
            BTC to the specified Bitcoin address. When the flow completes,
            outputs the deposit as a single tab-delimited line with the
            deposit address, current deposit state, deposit lot size in
            satoshis, and the transaction hash of the redemption Bitcoin
            transaction.

        courtesy-call
            Attempts to notify the deposit it is undercollateralized and
            should transition into courtesy call.

        liquidate [--for <funding-timeout|undercollateralization|courtesy-timeout|redemption-timeout>]
            Attempts to liquidate the deposit, reporting back the status of
            the liquidation . By default, looks for any available reason to
            liquidate. When the flow completes, outputs the deposit as a
            single tab-delimited line with the deposit address, current
            deposit state, deposit lot size in satoshis, and the liquidation
            status (\`liquidated\`, \`in-auction\`, or \`failed\`).

            --for <funding-timeout|undercollateralization|courtesy-timeout|redemption-timeout>
                If specified, only triggers liquidation for the specified
                reason. If the reason does not apply, reports \`not-applicable\`
                status.

        withdraw [--dry-run]
            Attempts to withdraw the current account's allowance from a tBTC
            deposit. Only the amount allowed for the current account is
            withdrawn. Outputs the withdrawn amount in wei once withdrawal
            is complete.

            --dry-run
                Outputs the amount that would be withdrawn in wei, but does
                not broadcast the transaction to withdraw it.

    lot-sizes
      Returns a list of the currently available lot sizes, one per line.

    supply
        Returns the current supply as a decimal amount in TBTC. 18 decimals of
        precision, but with a decimal point.

    supply-cap
        Returns the current supply cap as a decimal amount in TBTC.
```