### PR TITLE
Burst of bcoin: Bump bcoin to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -585,45 +585,45 @@
       },
       "dependencies": {
         "@ledgerhq/devices": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.21.0.tgz",
-          "integrity": "sha512-65XZgD2ykK7AJkcJuNEP8WD43HDkudA7NfB34U1T6pmPC6AgWoRYDNpJ23XQ8eiAImETlxv7FaDGUXSEpIQMGQ==",
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.22.0.tgz",
+          "integrity": "sha512-oJxhee/zlHmIx66zvQQTSpIsHOiiLjALemTX9oUtB4xQwFvoiptPnBCeTDTM9teode7wzk7oE9qdUAZuat+nCg==",
           "requires": {
-            "@ledgerhq/errors": "^5.21.0",
-            "@ledgerhq/logs": "^5.21.0",
-            "rxjs": "^6.6.0"
+            "@ledgerhq/errors": "^5.22.0",
+            "@ledgerhq/logs": "^5.22.0",
+            "rxjs": "^6.6.2"
           }
         },
         "@ledgerhq/errors": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.21.0.tgz",
-          "integrity": "sha512-sGfXoaVGfzrhnexu2TEdgL2FAjM7PUeobWdDBx3DJKE+ARje1y+i5+qg7gyvQL+9k4FV7mW2xMOcnUI3T2Zw0Q=="
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.22.0.tgz",
+          "integrity": "sha512-XDT0meBn39+q+JWzUFXmiFbVYLTy+uHRFMb9napcxyZ0Q/MdKkle9/vkgtvRHjPIkGobklXpyefsgH3BZQHukA=="
         },
         "@ledgerhq/hw-app-eth": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.21.0.tgz",
-          "integrity": "sha512-FKwwqp7IDgCq9ToL/JwO4S3HXr4LSI+Vr6KqeCtpCwRGNdvtiUHF3S9g2LtUroCcGXx9HTr2XL4hZzfrj+2jfg==",
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.22.0.tgz",
+          "integrity": "sha512-O+PqA1DGsdyjZ2DFW3r6hKqtaGCq3MNqaYUmqHvdp/wTOYIlgmiBKqhaobMTA+ufa46/8CKLDheW/8WcAu7tAA==",
           "requires": {
-            "@ledgerhq/errors": "^5.21.0",
-            "@ledgerhq/hw-transport": "^5.21.0",
+            "@ledgerhq/errors": "^5.22.0",
+            "@ledgerhq/hw-transport": "^5.22.0",
             "bignumber.js": "^9.0.0",
             "rlp": "^2.2.6"
           }
         },
         "@ledgerhq/hw-transport": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.21.0.tgz",
-          "integrity": "sha512-emVoy+ZEA19z+g6CsDcliVRRYDn4RzdH+zW9F37Z22uoMWslx2VNa+KdcKijmS3V3mkSLjle1cjwprPh61G8hQ==",
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.22.0.tgz",
+          "integrity": "sha512-MFfkVGYMYnr6fI4XGnJQNLd36JIrRpvd5WBmVSDhCO3UKUER2fJ9koVBGc97o7yXtE5IAlJKF+nR9HZJIa0lRQ==",
           "requires": {
-            "@ledgerhq/devices": "^5.21.0",
-            "@ledgerhq/errors": "^5.21.0",
+            "@ledgerhq/devices": "^5.22.0",
+            "@ledgerhq/errors": "^5.22.0",
             "events": "^3.2.0"
           }
         },
         "@ledgerhq/logs": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.21.0.tgz",
-          "integrity": "sha512-eyPXrKfQ+HSLcITB5MdSWhXlImE2qKWTLT2u6l+a9wiCZl5yimSqn0uC5evxaP0McKOW0wSntgfj+gOoKv+Paw=="
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.22.0.tgz",
+          "integrity": "sha512-jV4mJxD1aieORm+sK9bYakQd9GMLd7KAxgt2IaxhrTU+QD5Ne47mxQOTys9p7f5w25ujs3R+Px2t3KiMRASHtg=="
         },
         "bignumber.js": {
           "version": "9.0.0",
@@ -705,9 +705,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.28",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-              "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+              "version": "10.17.29",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+              "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
             },
             "elliptic": {
               "version": "6.3.3",
@@ -799,9 +799,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.28",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-              "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+              "version": "10.17.29",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+              "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
             }
           }
         },
@@ -1174,9 +1174,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.3.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0-rc.0.tgz",
-      "integrity": "sha512-+IxDsKYn8zC8Sut5UM5Mb7pIyySJmbpT6yQXZ2fnEk95QuFEK6IguSE2qKF9n4KNPCyxXkeD5qRTwGu9xNsKiw==",
+      "version": "1.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0-rc.1.tgz",
+      "integrity": "sha512-u12pMnmTRbwx7OYeZOzM3+7U4eE7tRco/FZwv/0kKVdwVFfsETVJD9s4SLOdwUrzzG13YNQHfYpD0blC2EYA3Q==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -1191,29 +1191,29 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.2.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-rc.1.tgz",
-      "integrity": "sha512-16++cWpAun6G6rUu1aQl+5YePgBEIEWWaLiwaOTjWpwHd9DE7h3a1jo7S+geEqH7l+zWCW9t3+HmY7cp65K+oQ==",
+      "version": "1.2.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-rc.3.tgz",
+      "integrity": "sha512-jcMXyZR/eZKNpgrVrD8WBAuq97y11OFFvWsLVNyssZdSRpM8D2GW4m1c2yjEE1gTePDYr4POR0wGCxkgBJ96KQ==",
       "requires": {
         "@keep-network/keep-core": ">1.3.0-rc <1.3.0",
-        "@keep-network/sortition-pools": "1.1.0",
+        "@keep-network/sortition-pools": "1.1.1",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
         "solidity-bytes-utils": "0.0.7"
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.0.tgz",
-      "integrity": "sha512-4mPp6f6HpfEdjfFM/PHwqabfnWc91gldbcIQEoS6bSfrqfrgFgmmOT6r9WO+Sqw9bR6Ve1tPWp3jpu6ufkPDww==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.1.tgz",
+      "integrity": "sha512-zdaVTew4xfDe65ZfO7B0TibpYVtm6iFB8ixvSqyzT+l6CPSZpj0IH/X0NIKPFTztL1yiibEsAUj3IaeppS3UmA==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@keep-network/tbtc": {
-      "version": "1.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0-rc.0.tgz",
-      "integrity": "sha512-IpeijbystYJFfr/OHwnSkCUBGm+cZOkvnEFr9FvP9TemX0xhQBbB+647eeasukuneflgNn9QrZJZXJHDzKVcCg==",
+      "version": "1.1.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0-rc.1.tgz",
+      "integrity": "sha512-v407R7Gj/R8rpk+cOuB9O6izn/rrYSL2HPDqQ4oPFdghYmkRjidoy4qOrzxIhQIvbG9hg4CJJongABrqNlyMhA==",
       "requires": {
         "@keep-network/keep-ecdsa": ">1.2.0-rc <1.2.0",
         "@summa-tx/bitcoin-spv-sol": "^3.1.0",
@@ -1533,9 +1533,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
         }
       }
     },
@@ -1652,7 +1652,8 @@
     },
     "@web3-js/scrypt-shim": {
       "version": "0.1.0",
-      "resolved": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+      "resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
+      "integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
       "requires": {
         "scryptsy": "^2.1.0",
         "semver": "^6.3.0"
@@ -1820,13 +1821,14 @@
       }
     },
     "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "assert-plus": {
@@ -2589,62 +2591,253 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
-    "bcfg": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",
-      "integrity": "sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
     "bcoin": {
-      "version": "git+https://github.com/bcoin-org/bcoin.git#8851582be817da7d6b6a1cfa6791b4baf3b8058f",
-      "from": "git+https://github.com/bcoin-org/bcoin.git#8851582",
+      "version": "git+https://github.com/bcoin-org/bcoin.git#2dece4fbe10fffa369e9dd0e8263eb57ba30dcac",
+      "from": "git+https://github.com/bcoin-org/bcoin.git#v2.1.2",
       "requires": {
-        "bcfg": "~0.1.6",
-        "bcrypto": "~3.1.11",
-        "bcurl": "^0.1.6",
-        "bdb": "~1.1.7",
-        "bdns": "~0.1.5",
-        "bevent": "~0.1.5",
-        "bfile": "~0.2.1",
-        "bfilter": "~1.0.5",
-        "bheep": "~0.1.5",
-        "binet": "~0.3.5",
-        "blgr": "~0.1.7",
-        "blru": "~0.1.6",
-        "blst": "~0.1.5",
-        "bmutex": "~0.1.6",
-        "bsert": "~0.0.10",
-        "bsip": "~0.1.9",
-        "bsock": "~0.1.9",
-        "bsocks": "~0.2.5",
-        "bstring": "~0.3.9",
-        "btcp": "~0.1.5",
-        "buffer-map": "~0.0.7",
-        "bufio": "~1.0.6",
-        "bupnp": "~0.2.6",
-        "bval": "~0.1.6",
-        "bweb": "~0.1.9",
-        "mrmr": "~0.1.8",
-        "n64": "~0.2.10"
+        "bcfg": "git+https://github.com/bcoin-org/bcfg.git#semver:~0.1.6",
+        "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.4",
+        "bcurl": "git+https://github.com/bcoin-org/bcurl.git#semver:^0.1.6",
+        "bdb": "git+https://github.com/bcoin-org/bdb.git#semver:~1.2.1",
+        "bdns": "git+https://github.com/bcoin-org/bdns.git#semver:~0.1.5",
+        "bevent": "git+https://github.com/bcoin-org/bevent.git#semver:~0.1.5",
+        "bfile": "git+https://github.com/bcoin-org/bfile.git#semver:~0.2.1",
+        "bfilter": "git+https://github.com/bcoin-org/bfilter.git#semver:~2.0.0",
+        "bheep": "git+https://github.com/bcoin-org/bheep.git#semver:~0.1.5",
+        "binet": "git+https://github.com/bcoin-org/binet.git#semver:~0.3.5",
+        "blgr": "git+https://github.com/bcoin-org/blgr.git#semver:~0.1.7",
+        "blru": "git+https://github.com/bcoin-org/blru.git#semver:~0.1.6",
+        "blst": "git+https://github.com/bcoin-org/blst.git#semver:~0.1.5",
+        "bmutex": "git+https://github.com/bcoin-org/bmutex.git#semver:~0.1.6",
+        "brq": "git+https://github.com/bcoin-org/brq.git#semver:~0.1.7",
+        "bs32": "git+https://github.com/bcoin-org/bs32.git#semver:=0.1.6",
+        "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
+        "bsock": "git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9",
+        "bsocks": "git+https://github.com/bcoin-org/bsocks.git#semver:~0.2.6",
+        "btcp": "git+https://github.com/bcoin-org/btcp.git#semver:~0.1.5",
+        "buffer-map": "git+https://github.com/chjj/buffer-map.git#semver:~0.0.7",
+        "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
+        "bupnp": "git+https://github.com/bcoin-org/bupnp.git#semver:~0.2.6",
+        "bval": "git+https://github.com/bcoin-org/bval.git#semver:~0.1.6",
+        "bweb": "git+https://github.com/bcoin-org/bweb.git#semver:=0.1.9",
+        "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1",
+        "n64": "git+https://github.com/chjj/n64.git#semver:~0.2.10",
+        "nan": "git+https://github.com/braydonf/nan.git#semver:=2.14.0"
       },
       "dependencies": {
-        "bcrypto": {
-          "version": "3.1.11",
-          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.11.tgz",
-          "integrity": "sha512-XHsle+v0aYjCyHZSwd3Insnu8GUe4cuf3+f07Z/mO+GLq60YqUyEIvpaSv4LAAJ4uf8UNYMSSQ0LslsV0r4tug==",
+        "bcfg": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/bcfg.git#semver:~0.1.6",
+          "bundled": true,
           "requires": {
-            "bsert": "~0.0.10",
+            "bsert": "~0.0.10"
+          }
+        },
+        "bcrypto": {
+          "version": "5.0.4",
+          "from": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.4",
+          "bundled": true,
+          "requires": {
             "bufio": "~1.0.6",
             "loady": "~0.0.1",
-            "nan": "^2.13.2"
+            "nan": "^2.14.0"
           }
+        },
+        "bcurl": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/bcurl.git#semver:^0.1.6",
+          "bundled": true,
+          "requires": {
+            "brq": "~0.1.7",
+            "bsert": "~0.0.10",
+            "bsock": "~0.1.8"
+          }
+        },
+        "bdb": {
+          "version": "1.2.1",
+          "from": "git+https://github.com/bcoin-org/bdb.git#semver:~1.2.1",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10",
+            "loady": "~0.0.1"
+          }
+        },
+        "bdns": {
+          "version": "0.1.5",
+          "from": "git+https://github.com/bcoin-org/bdns.git#semver:~0.1.5",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bevent": {
+          "version": "0.1.5",
+          "from": "git+https://github.com/bcoin-org/bevent.git#semver:~0.1.5",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bfile": {
+          "version": "0.2.2",
+          "from": "git+https://github.com/bcoin-org/bfile.git#semver:~0.2.1",
+          "bundled": true
+        },
+        "bfilter": {
+          "version": "2.0.0",
+          "from": "git+https://github.com/bcoin-org/bfilter.git#semver:~2.0.0",
+          "bundled": true,
+          "requires": {
+            "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.4",
+            "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
+            "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
+            "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1",
+            "nan": "git+https://github.com/braydonf/nan.git#semver:=2.14.0"
+          }
+        },
+        "bheep": {
+          "version": "0.1.5",
+          "from": "git+https://github.com/bcoin-org/bheep.git#semver:~0.1.5",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "binet": {
+          "version": "0.3.5",
+          "from": "git+https://github.com/bcoin-org/binet.git#semver:~0.3.5",
+          "bundled": true,
+          "requires": {
+            "bs32": "~0.1.5",
+            "bsert": "~0.0.10"
+          }
+        },
+        "blgr": {
+          "version": "0.1.7",
+          "from": "git+https://github.com/bcoin-org/blgr.git#semver:~0.1.7",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "blru": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/blru.git#semver:~0.1.6",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "blst": {
+          "version": "0.1.5",
+          "from": "git+https://github.com/bcoin-org/blst.git#semver:~0.1.5",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bmutex": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/bmutex.git#semver:~0.1.6",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "brq": {
+          "version": "0.1.8",
+          "from": "git+https://github.com/bcoin-org/brq.git#semver:~0.1.7",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bs32": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/bs32.git#semver:=0.1.6",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bsert": {
+          "version": "0.0.10",
+          "from": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
+          "bundled": true
+        },
+        "bsock": {
+          "version": "0.1.9",
+          "from": "git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bsocks": {
+          "version": "0.2.6",
+          "from": "git+https://github.com/bcoin-org/bsocks.git#semver:~0.2.6",
+          "bundled": true,
+          "requires": {
+            "binet": "~0.3.5",
+            "bsert": "~0.0.10"
+          }
+        },
+        "btcp": {
+          "version": "0.1.5",
+          "from": "git+https://github.com/bcoin-org/btcp.git#semver:~0.1.5",
+          "bundled": true
+        },
+        "buffer-map": {
+          "version": "0.0.7",
+          "from": "git+https://github.com/chjj/buffer-map.git#semver:~0.0.7",
+          "bundled": true
+        },
+        "bufio": {
+          "version": "1.0.6",
+          "from": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
+          "bundled": true
+        },
+        "bupnp": {
+          "version": "0.2.6",
+          "from": "git+https://github.com/bcoin-org/bupnp.git#semver:~0.2.6",
+          "bundled": true,
+          "requires": {
+            "binet": "~0.3.5",
+            "brq": "~0.1.7",
+            "bsert": "~0.0.10"
+          }
+        },
+        "bval": {
+          "version": "0.1.6",
+          "from": "git+https://github.com/bcoin-org/bval.git#semver:~0.1.6",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bweb": {
+          "version": "0.1.9",
+          "from": "git+https://github.com/bcoin-org/bweb.git#semver:=0.1.9",
+          "bundled": true,
+          "requires": {
+            "bsert": "~0.0.10",
+            "bsock": "~0.1.8"
+          }
+        },
+        "loady": {
+          "version": "0.0.1",
+          "from": "git+https://github.com/chjj/loady.git#semver:~0.0.1",
+          "bundled": true
+        },
+        "n64": {
+          "version": "0.2.10",
+          "from": "git+https://github.com/chjj/n64.git#semver:~0.2.10",
+          "bundled": true
         },
         "nan": {
           "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+          "from": "git+https://github.com/braydonf/nan.git#semver:=2.14.0",
+          "bundled": true
         }
       }
     },
@@ -2674,64 +2867,6 @@
         }
       }
     },
-    "bcurl": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.6.tgz",
-      "integrity": "sha512-noeDhfqFiUcNOUuZKErkXcbZfxBjn6duTfYPEfA4hAYXGr7gwVxkAWvIerxl3ZLLyn8jzh7Oi0nHlrLm1ST9Fw==",
-      "requires": {
-        "brq": "~0.1.7",
-        "bsert": "~0.0.10",
-        "bsock": "~0.1.8"
-      }
-    },
-    "bdb": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.7.tgz",
-      "integrity": "sha512-jtBnWEyDDK08dBbKL9LJeO2huZyBmbjBQMMVjU9RI1liJo6YDbv86uDHoaD4gniefd9pfxqOM1w6rYuwLVCXlQ==",
-      "requires": {
-        "bsert": "~0.0.10",
-        "loady": "~0.0.1"
-      }
-    },
-    "bdns": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
-      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "bevent": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
-      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "bfile": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
-      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg=="
-    },
-    "bfilter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz",
-      "integrity": "sha512-GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==",
-      "requires": {
-        "bsert": "~0.0.10",
-        "bufio": "~1.0.6",
-        "mrmr": "~0.1.6"
-      }
-    },
-    "bheep": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
-      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
     "big-integer": {
       "version": "1.6.48",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
@@ -2751,15 +2886,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
       "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
-    },
-    "binet": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.5.tgz",
-      "integrity": "sha512-suogkqXrt63Z76ABvwJjI28w+LWrRE53nwItDPz1VwNjHEuh1+rxudGYtoewFmMhkJ9pW/VGGnjoxP+AGzHgLQ==",
-      "requires": {
-        "bs32": "~0.1.5",
-        "bsert": "~0.0.10"
-      }
     },
     "bip32": {
       "version": "2.0.5",
@@ -2816,22 +2942,6 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
-    "blgr": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.7.tgz",
-      "integrity": "sha512-+jSaU2jnYqF+ec9e8nzjfjU7QhZIntkDNG8/AEwoxW7J3mmwvmUfAI5lm9BFYs1OzT+1UgIZTFHa2qWjTBURfw==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "blru": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
-      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
     "bls12377js": {
       "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
       "from": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
@@ -2841,29 +2951,21 @@
         "big-integer": "^1.6.44",
         "chai": "^4.2.0",
         "mocha": "^6.2.2",
-        "ts-node": "^8.4.1"
-      }
-    },
-    "blst": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
-      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
-      "requires": {
-        "bsert": "~0.0.10"
+        "ts-node": "^8.4.1",
+        "typescript": "^3.6.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.7",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+        }
       }
     },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
-    "bmutex": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
-      "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -2966,9 +3068,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
         },
         "elliptic": {
           "version": "6.5.3",
@@ -3013,22 +3115,6 @@
         "electron-to-chromium": "^1.3.47"
       }
     },
-    "brq": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
-      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "bs32": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
-      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -3051,62 +3137,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
       "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
-    },
-    "bsip": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.9.tgz",
-      "integrity": "sha512-i7cVEfCthASPB3BYKS/pZN/D4kh4vToIlSAFcVBLNjzYl1UirT3E2PIGSfNnYR2qZ3UW1qnDavrWEHhLeSKt2A==",
-      "requires": {
-        "bsert": "~0.0.10",
-        "loady": "~0.0.1",
-        "nan": "^2.13.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        }
-      }
-    },
-    "bsock": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
-      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "bsocks": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.5.tgz",
-      "integrity": "sha512-w1yG8JmfKPIaTDLuR9TIxJM2Ma6nAiInRpLNZ43g3qPnPHjawCC4SV6Bdy84bEJQX1zJWYTgdod/BnQlDhq4Gg==",
-      "requires": {
-        "binet": "~0.3.5",
-        "bsert": "~0.0.10"
-      }
-    },
-    "bstring": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.9.tgz",
-      "integrity": "sha512-D95flI7SXL+UsQi9mW+hH+AK2AFfafIJi+3GbbyTAWMe2FqwR9keBxsjGiGd/JM+77Y9WsC+M4EhZVNVcym9jw==",
-      "requires": {
-        "bsert": "~0.0.10",
-        "loady": "~0.0.1",
-        "nan": "^2.13.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        }
-      }
-    },
-    "btcp": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
-      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A=="
     },
     "buffer": {
       "version": "5.6.0",
@@ -3146,11 +3176,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
-    "buffer-map": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
-      "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ=="
-    },
     "buffer-reverse": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
@@ -3170,33 +3195,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
       "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
-    },
-    "bupnp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
-      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
-      "requires": {
-        "binet": "~0.3.5",
-        "brq": "~0.1.7",
-        "bsert": "~0.0.10"
-      }
-    },
-    "bval": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
-      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
-      "requires": {
-        "bsert": "~0.0.10"
-      }
-    },
-    "bweb": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
-      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
-      "requires": {
-        "bsert": "~0.0.10",
-        "bsock": "~0.1.8"
-      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -3218,9 +3216,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -4922,13 +4920,13 @@
       }
     },
     "ethers": {
-      "version": "4.0.47",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
-      "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+      "version": "4.0.48",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+      "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
       "requires": {
         "aes-js": "3.0.0",
         "bn.js": "^4.4.0",
-        "elliptic": "6.5.2",
+        "elliptic": "6.5.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
         "scrypt-js": "2.0.4",
@@ -4938,9 +4936,9 @@
       },
       "dependencies": {
         "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -19847,9 +19845,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
-      "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw=="
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.13.tgz",
+      "integrity": "sha512-USnpjJkD8St+wyshy154lF74JeauNCd8vrcusSlWjSFWitXzl7ZSuCunA/XxeVLqBv6DShrSfFMYdwGZ7x4hOw=="
     },
     "got": {
       "version": "9.6.0",
@@ -21109,26 +21107,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
-      "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
-    },
-    "mrmr": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.8.tgz",
-      "integrity": "sha512-lNav10EJsPZvlMqlBOYQ5atIO9jrlvbJ4/7asqunXY89dHooN5c+W6AV7jtvBRw4wFDR7TpEWfmBQgRGRVwBzA==",
-      "requires": {
-        "bsert": "~0.0.10",
-        "loady": "~0.0.1",
-        "nan": "^2.13.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        }
-      }
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
     },
     "ms": {
       "version": "2.0.0",
@@ -21140,11 +21121,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "n64": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
-      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ=="
     },
     "nan": {
       "version": "2.10.0",
@@ -21510,13 +21486,12 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "requires": {
-        "asn1.js": "^4.0.0",
+        "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
@@ -23414,9 +23389,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+          "version": "10.17.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+          "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
         }
       }
     },
@@ -23625,9 +23600,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+          "version": "10.17.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+          "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
         },
         "elliptic": {
           "version": "6.3.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@keep-network/keep-ecdsa": ">1.2.0-rc <1.2.0",
     "@keep-network/tbtc": ">1.1.0-rc <1.1.0",
-    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
+    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#v2.1.2",
     "bcrypto": "^4.1.0",
     "bufio": "^1.0.6",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -1,6 +1,5 @@
 /** @typedef { import("web3-eth-contract").Contract } EthereumContract */
 
-import bcoin from "bcoin"
 import secp256k1 from "bcrypto/lib/secp256k1.js"
 import BcryptoSignature from "bcrypto/lib/internal/signature.js"
 import BcoinPrimitives from "bcoin/lib/primitives/index.js"
@@ -14,7 +13,7 @@ import ElectrumClient from "./lib/ElectrumClient.js"
 
 import BN from "bn.js"
 
-const { KeyRing } = BcoinPrimitives
+const { KeyRing, Outpoint, Input, Output, TX } = BcoinPrimitives
 const { Script } = BcoinScript
 
 /** @enum {string} */
@@ -539,7 +538,7 @@ const BitcoinHelpers = {
         throw new Error(`failed to convert signature to DER format: [${err}]`)
       }
 
-      const hashType = Buffer.from([bcoin.Script.hashType.ALL])
+      const hashType = Buffer.from([Script.hashType.ALL])
       const sig = Buffer.concat([signatureDER, hashType])
 
       // Public Key
@@ -554,7 +553,7 @@ const BitcoinHelpers = {
       // Combine witness
       let signedTransaction
       try {
-        signedTransaction = bcoin.TX.fromRaw(
+        signedTransaction = TX.fromRaw(
           Buffer.from(unsignedTransaction, "hex"),
           null
         ).clone()
@@ -594,11 +593,11 @@ const BitcoinHelpers = {
       outputScript
     ) {
       // Input
-      const prevOutpoint = bcoin.Outpoint.fromRaw(
+      const prevOutpoint = Outpoint.fromRaw(
         Buffer.from(previousOutpoint, "hex")
       )
 
-      const input = bcoin.Input.fromOptions({
+      const input = Input.fromOptions({
         prevout: prevOutpoint,
         sequence: inputSequence
       })
@@ -606,13 +605,13 @@ const BitcoinHelpers = {
       // Output
       const rawOutputScript = Buffer.from(outputScript, "hex")
 
-      const output = bcoin.Output.fromOptions({
+      const output = Output.fromOptions({
         value: outputValue,
         script: rawOutputScript
       })
 
       // Transaction
-      const transaction = bcoin.TX.fromOptions({
+      const transaction = TX.fromOptions({
         inputs: [input],
         outputs: [output]
       })

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -1,6 +1,6 @@
 /** @typedef { import("web3-eth-contract").Contract } EthereumContract */
 
-import bcoin from "bcoin/lib/bcoin-browser.js"
+import bcoin from "bcoin"
 import secp256k1 from "bcrypto/lib/secp256k1.js"
 import BcryptoSignature from "bcrypto/lib/internal/signature.js"
 import BcoinPrimitives from "bcoin/lib/primitives/index.js"

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -430,6 +430,7 @@ export default class Deposit {
    */
   get requiredConfirmations() {
     // Lazily initialized.
+    /** @type {Promise<number>} */
     this._requiredConfirmations =
       this._requiredConfirmations ||
       (async () => {


### PR DESCRIPTION
The ancient verison of bcoin we were depending on worked just fine, but
a recent bump in tbtc-dapp revealed some issues with newer handling
by webpack and babel of `BigInt` literals, as well as mishandling of bcoin's
browser-specific remappings. Rather than try to escape `create-react-app`'s
straitjacket to try to fix these ourselves, this PR bumps the bcoin
dependency to the latest version, 2.1.2, and makes relevant adjustments
to ensure that transpiles and packages correctly for browser usage in
tbtc-dapp.

This is actively running on the Ropsten release currently deployed to
dapp.test.tbtc.network.