### PR TITLE
Thomas the Train Engine: If at first you don't succeed, try try again with exponential backoff

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -609,7 +609,9 @@ export default class Deposit {
    *         the deposit owner.
    */
   async mintTBTC() {
-    if (!(await this.contract.methods.inActive().call())) {
+    if (
+      !(await EthereumHelpers.callWithRetry(this.contract.methods.inActive()))
+    ) {
       throw new Error(
         "Can't mint TBTC with a deposit that isn't in ACTIVE state."
       )

--- a/src/lib/ElectrumClient.js
+++ b/src/lib/ElectrumClient.js
@@ -1,5 +1,6 @@
 import ElectrumClient from "electrum-client-js"
 import sha256 from "bcrypto/lib/sha256.js"
+import { backoffRetrier } from "./backoff"
 const { digest } = sha256
 
 /**
@@ -394,11 +395,14 @@ export default class Client {
    *         hexadecimal form.
    */
   async getTransactionMerkle(txHash, blockHeight) {
-    return await this.electrumClient
-      .blockchain_transaction_getMerkle(txHash, blockHeight)
-      .catch(err => {
-        throw new Error(`failed to get transaction merkle: [${err}]`)
-      })
+    return backoffRetrier(3, _ => _.message.includes("not in block at height"))(
+      async () =>
+        /** @type {TransactionMerkleBranch} */ (await this.electrumClient
+          .blockchain_transaction_getMerkle(txHash, blockHeight)
+          .catch(err => {
+            throw new Error(`failed to get transaction merkle: [${err}]`)
+          }))
+    )
   }
 
   /**

--- a/src/lib/backoff.js
+++ b/src/lib/backoff.js
@@ -1,0 +1,88 @@
+/**
+ * A convenience matcher for withBackoffRetries that retries irrespective of
+ * the error.
+ *
+ * @param {any} error The error to match against. Not necessarily an Error
+ *        instance, since the retriable function may throw a non-Error.
+ * @return {true} Always returns true.
+ */
+export function retryAll(error) {
+  return true
+}
+
+/**
+ * @callback ErrorMatcherFn A function that returns true if the passed error
+ *           matches and false otherwise. Used to determine if a given error is
+ *           eligible for retry in `withBackoffRetries`.
+ * @param {Error} error The error to check for eligibility.
+ * @return {boolean} True if the error matches, false otherwise.
+ */
+
+/**
+ * @callback RetrierFn A function that can retry any function passed to it a
+ *           set number of times, returning its result when it succeeds. Created
+ *           using `backoffRetrier`.
+ * @param {function(): Promise<T>} fn The function to be retried.
+ * @return {Promise<T>}
+ * @template T
+ */
+
+/**
+ * Returns a retrier that can be passed a function to be retried `retries`
+ * number of times, with exponential backoff. The result will return the
+ * function's return value if no exceptions are thrown. It will only retry if
+ * the function throws an exception matched by `matcher`; {@see retryAll} can
+ * be used to retry no matter the exception, though this is not necessarily
+ * recommended in production.
+ *
+ * Example usage:
+ *
+ *      await url.get("https://example.com/") // may transiently fail
+ *      // Retries 3 times with exponential backoff, no matter what error is
+ *      // reported by `url.get`.
+ *      backoffRetrier(3)(async () => url.get("https://example.com"))
+ *      // Retries 3 times with exponential backoff, but only if the error
+ *      // message includes "server unavailable".
+ *      backoffRetrier(3, (_) => _.message.includes('server unavailable'))(
+ *        async () => url.get("https://example.com"))
+ *      )
+ *
+ * @template T
+ * @param {number} retries The number of retries to perform before bubbling the
+ *        failure out.
+ * @param {ErrorMatcherFn} [matcher=retryAll] A matcher function that receives
+ *        the error when an exception is thrown, and returns true if
+ * @return {RetrierFn<T>}
+ */
+export function backoffRetrier(retries, matcher) {
+  const errorMatcher = matcher || retryAll // default to always retrying
+
+  return async (/** @type {() => Promise<any>} */ fn) => {
+    for (let attempt = 0; attempt < retries; attempt++) {
+      try {
+        console.debug(`making attempt number ${attempt}`)
+
+        return await fn()
+      } catch (error) {
+        if (!errorMatcher(error)) {
+          // If the matcher doesn't match this error, rethrow and stop.
+          throw error
+        }
+
+        const backoffMillis = Math.pow(2, attempt) * 1000
+        const jitterMillis = Math.floor(Math.random() * 100)
+        const waitMillis = backoffMillis + jitterMillis
+
+        console.debug(
+          `attempt ${attempt} failed: ${error}; ` +
+            `retrying after ${waitMillis} milliseconds`
+        )
+
+        await new Promise(resolve => setTimeout(resolve, waitMillis))
+      }
+    }
+
+    // Last attempt, unguarded.
+    return await fn()
+  }
+}


### PR DESCRIPTION
Introduce a generalized exponential backoff helper, `backoffRetrier`, use it
for `sendSafelyRetryable`, introduce `EthereumHelpers.callWithRetry` for
use in the minting flow, and add retries to `ElectrumClient`'s
`getTransactionMerkle` function.

This should close keep-network/tbtc-dapp#253 and
close keep-network/tbtc-dapp#263.