### PR TITLE
UTX-Who?: Filter redemption Bitcoin transactions by funding UTXO

### DIFF
--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -166,16 +166,18 @@ export default class Redemption {
             `chain for deposit ${this.deposit.address}...`
         )
 
-        const { utxoValue, requestedFee, redeemerOutputScript } = await this
-          .redemptionDetails
+        const {
+          utxoValue,
+          requestedFee,
+          redeemerOutputScript,
+          outpoint: fundingOutpoint
+        } = await this.redemptionDetails
         const expectedValue = utxoValue.sub(requestedFee).toNumber()
-        // FIXME Check that the transaction spends the right UTXO, not just
-        // FIXME that it's the right amount to the right address. outpoint
-        // FIXME compared against vin is probably the move here.
         /** @type {import("./BitcoinHelpers.js").PartialTransactionInBlock?} */
         let transaction = await BitcoinHelpers.Transaction.findScript(
           EthereumHelpers.bytesToRaw(redeemerOutputScript),
-          expectedValue
+          expectedValue,
+          fundingOutpoint
         )
 
         if (!transaction) {

--- a/src/lib/ElectrumClient.js
+++ b/src/lib/ElectrumClient.js
@@ -10,6 +10,15 @@ const { digest } = sha256
  */
 
 /**
+ * @typedef {object} TransactionInput
+ * @property {object} scriptSig The scriptsig that unlocks the specified
+ *           outpoint for spending.
+ * @property {string} txid The id of the transaction the input UTXO comes from.
+ * @property {number} vout The vout from the specified txid that is being used
+ *           for this input.
+ */
+
+/**
  * @typedef {object} TransactionOutput
  * @property {number} n The 0-based index of the output.
  * @property {number} value The value of the output in BTC.
@@ -28,6 +37,7 @@ const { digest } = sha256
  *           string.
  * @property {string} txid The transaction ID (or transaction hash) as an
  *           unprefixed hex string.
+ * @property {TransactionInput[]} vin The vector of transaction inputs.
  * @property {TransactionOutput[]} vout The vector of transaction outputs.
  */
 


### PR DESCRIPTION
During redemption, tbtc.js's `Deposit` object has to identify the Bitcoin
transaction that represents the redemption of this deposit (once it has
been broadcast). The previous strategy was very naive, matching solely
based on the value + receiver script of the transaction output. This meant
that an account redeeming two deposits of the same value to the same
receiver script would lead to confusion in tbtc.js, and potentially submitting
a proof for a transaction that doesn't match the deposit (which fails on the
contract side).

The new approach adds filtering by the outpoint (a transaction id + output
index that identifies the UTXO) used for the transaction input. The outpoint
from the funding UTXO is passed through, and only a transaction that matches
output value, receiver script, and outpoint is matched.

Closes keep-network/tbtc-dapp#348.