### PR TITLE
In `purchaseSignerBondsAtAuction` get rightful ETH by calling `withdrawFunds`

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1310,6 +1310,16 @@ export default class Deposit {
   }
 
   /**
+   * Pays off the deposit balance and closes the liquidation auction
+   * via `Deposit.purchaseSignerBondsAtAuction`, then withdraws the purchased
+   * ETH by calling `DepositUtils.withdrawFunds`.
+   */
+  async takeAuction() {
+    await this.purchaseSignerBondsAtAuction()
+    await this.withdrawFunds()
+  }
+
+  /**
    * Purchases the signer bonds and closes the liquidation auction.
    */
   async purchaseSignerBondsAtAuction() {

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1331,6 +1331,10 @@ export default class Deposit {
     await EthereumHelpers.sendSafely(
       this.contract.methods.purchaseSignerBondsAtAuction()
     )
+
+    await EthereumHelpers.sendSafely(
+      this.contract.methods.withdrawFunds()
+    )
   }
 
   /**

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1336,6 +1336,15 @@ export default class Deposit {
   }
 
   /**
+   * Withdraw caller's allowance.
+   * Withdrawals can only happen when a contract is in an end-state.
+   */
+  async withdrawFunds() {
+    // FIXME Need systemic handling of default from address.
+    await EthereumHelpers.sendSafely(this.contract.methods.withdrawFunds())
+  }
+
+  /**
    * Gets the current value of signer bonds at auction.
    * Only callable if the deposit is in the liqudation state.
    * @return {Promise<BN>} auction value in wei.

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1341,8 +1341,6 @@ export default class Deposit {
     await EthereumHelpers.sendSafely(
       this.contract.methods.purchaseSignerBondsAtAuction()
     )
-
-    await EthereumHelpers.sendSafely(this.contract.methods.withdrawFunds())
   }
 
   /**

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1332,9 +1332,7 @@ export default class Deposit {
       this.contract.methods.purchaseSignerBondsAtAuction()
     )
 
-    await EthereumHelpers.sendSafely(
-      this.contract.methods.withdrawFunds()
-    )
+    await EthereumHelpers.sendSafely(this.contract.methods.withdrawFunds())
   }
 
   /**


### PR DESCRIPTION
# Description
- sendSafely action on the `withdrawFunds` method: 
    This way the purchaser will also get the sanctioned ETH as part of `purchaseSignerBondsAtAuction`

## Checklist
- [X] Fork keep-network/tbtc.js
- [X] Clone your fork
- [X] Describe the change you are intending to undertake in the PR description.

Before marking the PR as ready for review, make sure:
- [X] It passes the linter checks.
- [ ] Your changes have sufficient test coverage (e.g regression tests have been added for bug fixes, unit tests for new features)
tests disabled at the moment
- [X] Commits must be signed.