### PR TITLE
Upgrade jq on CI runner

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,6 +25,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Upgrade jq
+      run: |
+        wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+        chmod +x jq-linux64
+        sudo mv jq-linux64 /usr/bin/jq
     - run: npm ci
     - run: npm run lint
     - run: npm run build --if-present


### PR DESCRIPTION
Fixes type checks on CI. 

See https://github.com/keep-network/tbtc.js/pull/85#discussion_r492771397 for discussion.