### PR TITLE
Engineering Estimates: Force deposit creation gas limit

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -258,7 +258,7 @@ export class DepositFactory {
 
     const result = await EthereumHelpers.sendSafely(
       this.depositFactory().methods.createDeposit(lotSize.toString()),
-      { value: creationCost }
+      { value: creationCost, gas: 1600000 }
     )
 
     const createdEvent = EthereumHelpers.readEventFromTransaction(

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -181,7 +181,7 @@ async function sendSafely(boundContractMethod, sendParams, forceSend = false) {
     return boundContractMethod.send({
       from: "", // FIXME Need systemic handling of default from address.
       ...sendParams,
-      gas: gasEstimate
+      gas: Math.max(gasEstimate, (sendParams && sendParams.gas) || 0)
     })
   } catch (exception) {
     // For an always failing transaction, if forceSend is set, send it anyway.


### PR DESCRIPTION
This PR deals with an issue where sometimes `estimateGas` returns a
slightly-too-low value for `createDeposit`'s gas needs. `createDeposit`
needs ~1.5M-1.575M gas, but sometimes the esimates bring in a value closer to
1.45M. When these transactions run out of gas, they still eat the full 1.45M
gas limit, which is super lame.

This PR forces the gas limit for deposit creation to 1.6M (subject to user
confirmation of course) to avoid these issues.
