### PR TITLE
Changing fixed gas estimate for deposit creation to a multipier

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -482,7 +482,7 @@ const BitcoinHelpers = {
     estimateFee: async function(tbtcConstantsContract) {
       return new BN(
         await tbtcConstantsContract.methods.getMinimumRedemptionFee().call()
-      ).muln(4)
+      ).muln(18)
     },
     /**
      * For the given `transactionID`, constructs an SPV proof that proves it

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -282,7 +282,9 @@ export class DepositFactory {
 
     const result = await EthereumHelpers.sendSafely(
       this.depositFactory().methods.createDeposit(lotSize.toString()),
-      { value: creationCost, gas: 1700000 }
+      { value: creationCost },
+      false,
+      1.2
     )
 
     const createdEvent = EthereumHelpers.readEventFromTransaction(

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -258,7 +258,7 @@ export class DepositFactory {
 
     const result = await EthereumHelpers.sendSafely(
       this.depositFactory().methods.createDeposit(lotSize.toString()),
-      { value: creationCost, gas: 1600000 }
+      { value: creationCost, gas: 1700000 }
     )
 
     const createdEvent = EthereumHelpers.readEventFromTransaction(

--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -237,9 +237,10 @@ async function sendSafely(
     return boundContractMethod.send({
       from: "", // FIXME Need systemic handling of default from address.
       ...sendParams,
-      gas:
+      gas: Math.round(
         Math.max(gasEstimate, (sendParams && sendParams.gas) || 0) *
-        gasMultiplier
+          gasMultiplier
+      )
     })
   } catch (exception) {
     // For an always failing transaction, if forceSend is set, send it anyway.


### PR DESCRIPTION
This PR is closely related to the changes made in https://github.com/keep-network/tbtc.js/pull/96

Sortition pool updates can mean variation between the required gas at
gas estimation time and at transaction mining time. Rather than try to
set a fixed cost, gas estimation is now followed, but with a multiplier boost
applied on top for deposit creation transactions.

As an addendum, Bitcoin fee estimates, which are still faked as a fixed value,
are now boosted by 4.5x more to account for recent Bitcoin network fee
movement.