### PR TITLE
Fallaback getEvent to past events querying on subscription error

### DIFF
--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -113,9 +113,14 @@ function getEvent(sourceContract, eventName, filter) {
     )
 
     sourceContract.once(eventName, { filter }, (error, event) => {
-      clearInterval(handle)
-      if (error) reject(error)
-      else resolve(event)
+      if (error) {
+        // We are not throwing an error as we want to fallback to querying past
+        // events in interval defined above.
+        console.warn(`failed to register for ${eventName}:`, error.message)
+      } else {
+        resolve(event)
+        clearInterval(handle)
+      }
     })
   })
 }


### PR DESCRIPTION
The change was made after testing tbtc.js `getEvent` function locally.
When subscribing to an event in `once` function the following error was returned:
`The method eth_subscribe does not exist/is not available`. 
As a result `clearInterval` function was executed and the fallback defined in `setInterval` was never executed.