### PR TITLE
Sanding Block: Add bin/tbtc.js support for computing digests and broadcasting Bitcoin transactions

### DIFF
--- a/bin/commands/bitcoin.js
+++ b/bin/commands/bitcoin.js
@@ -1,0 +1,212 @@
+/** @typedef {import('../tbtc.js').CommandAction} CommandAction */
+/** @typedef {import('../../src/TBTC.js').ElectrumConfig} ElectrumConfig */
+/** @typedef {import('../../src/TBTC.js').Web3} Web3 */
+/** @typedef {import('../../src/TBTC.js').TBTC} TBTCInstance */
+
+import { BitcoinHelpers } from "../../index.js"
+
+import sha256 from "bcrypto/lib/sha256-browser.js"
+const { digest } = sha256
+
+export const bitcoinCommandHelp = [
+  `digest <transaction-id> <output-index> <output-address>
+    Builds a new Bitcoin transaction that can be replaced by fee and outputs the
+    digest for that transaction. The transaction id is the id of the transaction
+    whose output will be used as an input to this transaction. The output index
+    is the index in the referenced transaction that should be used as an input
+    to this transaction. The output address should be a bech32 Bitcoin
+    address, which will be set up to receive the value at the given transaction
+    id and output index, less a Bitcoin transaction fee.`,
+  `broadcast <transaction-id> <output-index> <output-address> <signer-pubkey> <digest-signature>
+    Builds a new Bitcoin transaction that can be replaced by fee and broadcasts
+    it to the Bitcoin chain. The transaction id is the id of the transaction
+    whose output will be used as an input to this transaction. The output index
+    is the index in the referenced transaction that should be used as an input
+    to this transaction. The output address should be a bech32 Bitcoin
+    address, which will be set up to receive the value at the given transaction
+    id and output index, less a Bitcoin transaction fee. The signer pubkey is
+    the public key of the signer as an unprefixed 64-byte hex string of
+    concatenated x and y coordinates. The digest signature is an unprefixed
+    64-byte hex string representation of the signature's r and s values.`
+]
+
+/**
+ * @param {Web3} web3 An initialized Web3 instance TBTC is configured to use.
+ * @param {Array<string>} args
+ * @return {CommandAction | null}
+ */
+export function parseBitcoinCommand(web3, args) {
+  if (args.length > 0) {
+    const [command, ...commandArgs] = args
+    switch (command) {
+      case "digest":
+        {
+          const [
+            previousTransactionID,
+            previousOutputIndex,
+            outputAddress,
+            ...extra
+          ] = commandArgs
+
+          if (extra.length === 0) {
+            return async tbtc => {
+              const toBN = web3.utils.toBN
+              const rawOutputScript = BitcoinHelpers.Address.toRawScript(
+                outputAddress
+              )
+              const rawPreviousOutpoint = Buffer.concat([
+                toBN(previousTransactionID).toArrayLike(Buffer, "le", 32),
+                toBN(previousOutputIndex).toArrayLike(Buffer, "le", 4)
+              ])
+
+              const {
+                value: previousOutputValueBtc,
+                address: previousOutputAddress
+              } = await BitcoinHelpers.Transaction.getSimpleOutput(
+                previousTransactionID,
+                parseInt(previousOutputIndex, 16)
+              )
+              const previousOutputValue =
+                previousOutputValueBtc *
+                BitcoinHelpers.satoshisPerBtc.toNumber()
+              const rawPreviousOutputScript = BitcoinHelpers.Address.toRawScript(
+                previousOutputAddress
+              )
+              const transactionFee = await BitcoinHelpers.Transaction.estimateFee(
+                tbtc.depositFactory.constants()
+              )
+
+              const outputValue = toBN(previousOutputValue).sub(
+                transactionFee.divn(4)
+              )
+              /** @type {Buffer} */
+              const outputValueBytes = outputValue.toArrayLike(Buffer, "le", 8)
+
+              // Construct per BIP-143; see https://en.bitcoin.it/wiki/BIP_0143
+              // for more.
+              const sighashPreimage = Buffer.concat(
+                [
+                  // version
+                  `01000000`,
+                  // hashPrevouts
+                  digest(digest(rawPreviousOutpoint)),
+                  // hashSequence(00000000)
+                  digest(digest(Buffer.from("00000000", "hex"))),
+                  // outpoint
+                  rawPreviousOutpoint,
+                  // P2wPKH script:
+                  Buffer.concat([
+                    // length, dup, hash160, pkh_length
+                    Buffer.from("1976a914", "hex"),
+                    // pkh, without prefix length info
+                    rawPreviousOutputScript.slice(2),
+                    // equal, checksig
+                    Buffer.from("88ac", "hex")
+                  ]),
+                  // 8-byte little-endian input value (= previous output value)
+                  toBN(previousOutputValue).toArrayLike(Buffer, "le", 8),
+                  // input nSequence
+                  "00000000",
+                  // hash of the single output
+                  digest(
+                    digest(
+                      Buffer.concat([
+                        // value bytes
+                        outputValueBytes,
+                        // length of output script
+                        Buffer.of(rawOutputScript.byteLength),
+                        // output script
+                        rawOutputScript
+                      ])
+                    )
+                  ),
+                  // nLockTime
+                  "00000000",
+                  // SIG_ALL
+                  "01000000"
+                ].map(_ => Buffer.from(_, "hex"))
+              )
+
+              return digest(digest(sighashPreimage)).toString("hex")
+            }
+          }
+        }
+        break
+      case "broadcast": {
+        const [
+          previousTransactionID,
+          previousOutputIndex,
+          outputAddress,
+          publicKeyString,
+          digestSignature,
+          ...extra
+        ] = commandArgs
+
+        if (extra.length === 0) {
+          return async tbtc => {
+            const toBN = web3.utils.toBN
+            const rawOutputScript = BitcoinHelpers.Address.toRawScript(
+              outputAddress
+            )
+            const rawPreviousOutpoint = Buffer.concat([
+              toBN(previousTransactionID).toArrayLike(Buffer, "le", 32),
+              toBN(previousOutputIndex).toArrayLike(Buffer, "le", 4)
+            ])
+
+            const {
+              value: previousOutputValueBtc
+            } = await BitcoinHelpers.Transaction.getSimpleOutput(
+              previousTransactionID,
+              parseInt(previousOutputIndex, 16)
+            )
+            const previousOutputValue =
+              previousOutputValueBtc * BitcoinHelpers.satoshisPerBtc.toNumber()
+            const transactionFee = await BitcoinHelpers.Transaction.estimateFee(
+              tbtc.depositFactory.constants()
+            )
+
+            const outputValue = toBN(previousOutputValue).sub(
+              transactionFee.divn(4)
+            )
+
+            const rawTransaction = BitcoinHelpers.Transaction.constructOneInputOneOutputWitnessTransaction(
+              rawPreviousOutpoint.toString("hex"),
+              // We set sequence to `0` to be able to replace by fee. It reflects
+              // bitcoin-spv:
+              // https://github.com/summa-tx/bitcoin-spv/blob/2a9d594d9b14080bdbff2a899c16ffbf40d62eef/solidity/contracts/CheckBitcoinSigs.sol#L154
+              0,
+              outputValue.toNumber(),
+              rawOutputScript.toString("hex")
+            )
+
+            const signatureR = digestSignature.slice(0, 64)
+            const signatureS = digestSignature.slice(64)
+            const publicKeyPoint = BitcoinHelpers.Address.splitPublicKey(
+              publicKeyString
+            )
+
+            const signedTransaction = BitcoinHelpers.Transaction.addWitnessSignature(
+              rawTransaction,
+              0,
+              signatureR,
+              signatureS,
+              BitcoinHelpers.publicKeyPointToPublicKeyString(
+                publicKeyPoint.x.toString("hex"),
+                publicKeyPoint.y.toString("hex")
+              )
+            )
+
+            const transaction = await BitcoinHelpers.Transaction.broadcast(
+              signedTransaction
+            )
+
+            return transaction.transactionID
+          }
+        }
+      }
+    }
+  }
+
+  // If we're here, no command matched.
+  return null
+}

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -155,10 +155,11 @@ ${depositCommandHelp
         .join("\n")
   )
   .join("\n\n")}
+
 ${bitcoinCommandHelp
   .map(
     _ =>
-      "    deposit " +
+      "    bitcoin " +
       _.split("\n")[0] +
       "\n" +
       _.split("\n")

--- a/bin/tbtc.js
+++ b/bin/tbtc.js
@@ -5,6 +5,7 @@ import ProviderEngine from "web3-provider-engine"
 import WebsocketSubprovider from "web3-provider-engine/subproviders/websocket.js"
 import TBTC from "../index.js"
 import { depositCommandHelp, parseDepositCommand } from "./commands/deposit.js"
+import { bitcoinCommandHelp, parseBitcoinCommand } from "./commands/bitcoin.js"
 import {
   findAndConsumeArgsExistence,
   findAndConsumeArgsValues
@@ -70,6 +71,9 @@ let action = null
 switch (commandArgs[0]) {
   case "deposit":
     action = parseDepositCommand(web3, commandArgs.slice(1))
+    break
+  case "bitcoin":
+    action = parseBitcoinCommand(web3, commandArgs.slice(1))
     break
   case "lot-sizes":
     if (commandArgs.length == 1) {
@@ -140,6 +144,18 @@ Supported flags:
 
 Supported commands:
 ${depositCommandHelp
+  .map(
+    _ =>
+      "    deposit " +
+      _.split("\n")[0] +
+      "\n" +
+      _.split("\n")
+        .slice(1)
+        .map(_ => "    " + _)
+        .join("\n")
+  )
+  .join("\n\n")}
+${bitcoinCommandHelp
   .map(
     _ =>
       "    deposit " +

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -391,6 +391,28 @@ const BitcoinHelpers = {
       })
     },
     /**
+     * Looks up and returns the value and receiver address of a simple output
+     * in a transaction, given the transaction id and output index. Note that
+     * this assumes the output is to a single address rather than a multisig.
+     *
+     * @param {string} transactionID A hex Bitcoin transaction id hash.
+     * @param {number} outputIndex The index of the output in the referenced
+     *        transaction whose value to fetch.
+     * @return {Promise<{ value: number, address: string }>} The value of the
+     *         output at the given index in the given transaction.
+     */
+    getSimpleOutput: async function(transactionID, outputIndex) {
+      return BitcoinHelpers.withElectrumClient(async electrumClient => {
+        const { vout } = await electrumClient.getTransaction(transactionID)
+        const output = vout[outputIndex]
+
+        return {
+          value: output.value,
+          address: output.scriptPubKey.addresses[0]
+        }
+      })
+    },
+    /**
      * Checks the given Bitcoin `transactionID` to ensure it has at least
      * `requiredConfirmations` on-chain. If it does, resolves the returned
      * promise with the current number of on-chain confirmations. If it does

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -970,8 +970,14 @@ export default class Deposit {
    * a deposit, then transfer the deposit to a service provider who will
    * handle deposit qualification.
    *
+   * A deposit can be automatically pushed all the way through a mint (and with
+   * one fewer transaction) by using the `autoMint` method instead.
+   *
    * Calling this function more than once will return the existing state of
-   * the first auto submission process, rather than restarting the process.
+   * the first auto submission or minting process, rather than restarting the
+   * process. `autoMint` and `autoSubmission` share an auto-submission state,
+   * so a deposit cannot start auto-submitting and then switch to auto-minting
+   * mid-stream---whichever is called first will be the flow that will occur.
    *
    * @return {AutoSubmitState} An object with promises to various stages of
    *         the auto-submit lifetime. Each promise can be fulfilled or
@@ -1010,6 +1016,36 @@ export default class Deposit {
     return this.autoSubmittingState
   }
 
+  /**
+   * This method enables the deposit's auto-minting capabilities. In
+   * auto-mint mode, the deposit will automatically monitor for a new
+   * Bitcoin transaction to the deposit signers' Bitcoin wallet, then watch
+   * that transaction until it has accumulated sufficient work for proof
+   * of funding to be submitted to the deposit, then submit a transaction to
+   * simultaneously qualify it, move it into the ACTIVE state, and finally
+   * turn the deposit over to the vending machine to mint TBTC.
+   *
+   * Without calling this function, the deposit will do none of those things;
+   * instead, the caller will be in charge of managing (or choosing not to)
+   * this process. This can be useful, for example, if a dApp wants to open
+   * a deposit, then transfer the deposit to a service provider who will
+   * handle deposit qualification.
+   *
+   * A deposit can be automatically pushed through the qualification flow
+   * without minting at the end (i.e., preserving the owner's possession of the
+   * deposit) by using the `autoSubmit` method instead.
+   *
+   * Calling this function more than once will return the existing state of
+   * the first auto submission or minting process, rather than restarting the
+   * process. `autoMint` and `autoSubmission` share an auto-submission state,
+   * so a deposit cannot start auto-submitting and then switch to auto-minting
+   * mid-stream---whichever is called first will be the flow that will occur.
+   *
+   * @return {AutoSubmitState} An object with promises to various stages of
+   *         the auto-submit lifetime. Each promise can be fulfilled or
+   *         rejected, and they are in a sequence where later promises will be
+   *         rejected by earlier ones.
+   */
   autoMint() {
     // Only enable auto-submitting once.
     if (this.autoSubmittingState) {


### PR DESCRIPTION
It's a bit sloppy right now, but it does the trick. Here is the help doc:

```
    bitcoin digest <transaction-id> <output-index> <output-address>
        Builds a new Bitcoin transaction that can be replaced by fee and outputs the
        digest for that transaction. The transaction id is the id of the transaction
        whose output will be used as an input to this transaction. The output index
        is the index in the referenced transaction that should be used as an input
        to this transaction. The output address should be a bech32 Bitcoin
        address, which will be set up to receive the value at the given transaction
        id and output index, less a Bitcoin transaction fee.

    bitcoin broadcast <transaction-id> <output-index> <output-address> <signer-pubkey> <digest-signature>
        Builds a new Bitcoin transaction that can be replaced by fee and broadcasts
        it to the Bitcoin chain. The transaction id is the id of the transaction
        whose output will be used as an input to this transaction. The output index
        is the index in the referenced transaction that should be used as an input
        to this transaction. The output address should be a bech32 Bitcoin
        address, which will be set up to receive the value at the given transaction
        id and output index, less a Bitcoin transaction fee. The signer pubkey is
        the public key of the signer as an unprefixed 64-byte hex string of
        concatenated x and y coordinates. The digest signature is an unprefixed
        64-byte hex string representation of the signature's r and s values.
```

Already used to push some txes 😎 