### PR TITLE
Updated the way outpoint is assembled to find matching bitcoin transaction

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -711,8 +711,19 @@ const BitcoinHelpers = {
           const outpointMatches = (
             await electrumClient.getTransaction(tx.tx_hash)
           ).vin.some(({ txid, vout }) => {
-            const inputOutpoint = txid + vout
-            return inputOutpoint == outpoint
+            const voutBuffer = Buffer.alloc(4)
+            voutBuffer.writeUIntBE(vout, 0, 4)
+
+            const actualOutpoint = Buffer.concat([
+              voutBuffer,
+              Buffer.from(txid, "hex")
+            ]).reverse()
+
+            return (
+              actualOutpoint.compare(
+                Buffer.from(outpoint.replace("0x", ""), "hex")
+              ) === 0
+            )
           })
 
           if (!outpointMatches) {


### PR DESCRIPTION
Introduced some updates to outpoint assembling when finding matching transactions to match the format of passed expected outpoint.

Sample transaction input data obtained from electrum:
```
txid: 2e679307cf139b5a486511738140e7bb7ea5eec08c0028d6f6a54d656307603b
vout: 1
```

Sample outpoint passed to the function:
```
0x3b600763654da5f6d628008cc0eea57ebbe74081731165485a9b13cf0793672e01000000
```

We convert transaction details to match this format. It is constructed by combining 4 byte `vout` number and `txid`. Bytes are reversed at the end.