### PR TITLE
Updated the way to look for past transactions in electrum

### DIFF
--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -713,6 +713,9 @@ const BitcoinHelpers = {
         })
 
         const matchingOutput = tx.vout.find(({ scriptPubKey, value }) => {
+          // NOTE: We're looking for transactions with value greater or equal
+          // the expected value. This is not looking only for transactions that
+          // value is exactly as expected!
           return scriptPubKey.hex === receiverScript && value >= expectedValue
         })
 

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -705,7 +705,7 @@ const BitcoinHelpers = {
       )
 
       /** @type TransactionInBlock[] */
-      let transactions = []
+      const transactions = []
 
       transactionsWithScript.forEach(tx => {
         if (!tx) {

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -708,12 +708,6 @@ const BitcoinHelpers = {
       const transactions = []
 
       transactionsWithScript.forEach(tx => {
-        if (!tx) {
-          // TODO: Workaround for a case where ElectrumClient.getTransactionsForScript
-          // fails to get transaction details; solve it properly in ElectrumClient.
-          return
-        }
-
         tx.vout.forEach(_ => {
           _.value = _.value * BitcoinHelpers.satoshisPerBtc.toNumber()
         })

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -45,6 +45,7 @@ export const BitcoinNetwork = {
  * @property {string} transactionID Transaction ID.
  * @property {number} outputPosition Position of output in the transaction.
  * @property {number} value Value of the output (satoshis).
+ * @property {number} confirmations Number of chain confirmations.
  */
 
 /**
@@ -676,9 +677,10 @@ const BitcoinHelpers = {
 
     // Raw helpers.
     /**
-     * Finds a transaction to the given `receiverScript` of the given
+     * Finds a transaction to the given `receiverScript` of at least the given
      * `expectedValue` using the given `electrumClient`. If there is more
-     * than one such transaction, returns the most recent one.
+     * than one such transaction, returns the one with the most confirmations or
+     * the highest value. It includes also transactions from mempool.
      *
      * @param {ElectrumClient} electrumClient An already-initialized Electrum client.
      * @param {string} receiverScript A receiver script.
@@ -698,39 +700,82 @@ const BitcoinHelpers = {
       expectedValue,
       outpoint
     ) {
-      const unspentTransactions = await electrumClient.getUnspentToScript(
+      const transactionsWithScript = await electrumClient.getTransactionsForScript(
         receiverScript
       )
 
-      for (const tx of unspentTransactions.reverse()) {
-        if (tx.value !== expectedValue) {
-          // Skip if the value doesn't match.
-          continue
-        }
-        if (typeof outpoint !== "undefined") {
-          const outpointMatches = (
-            await electrumClient.getTransaction(tx.tx_hash)
-          ).vin.some(({ txid, vout }) => {
-            const inputOutpoint = txid + vout
-            return inputOutpoint == outpoint
-          })
+      /** @type TransactionInBlock[] */
+      let transactions = []
 
-          if (!outpointMatches) {
-            // If an outpoint filter is passed, skip if the outpoint isn't spent
-            // by the transaction.
-            continue
+      transactionsWithScript.forEach(tx => {
+        if (!tx) {
+          // TODO: Workaround for a case where ElectrumClient.getTransactionsForScript
+          // fails to get transaction details; solve it properly in ElectrumClient.
+          return
+        }
+
+        tx.vout.forEach(_ => {
+          _.value = _.value * BitcoinHelpers.satoshisPerBtc.toNumber()
+        })
+
+        const matchingOutput = tx.vout.find(({ scriptPubKey, value }) => {
+          return scriptPubKey.hex === receiverScript && value > expectedValue
+        })
+
+        if (!matchingOutput) {
+          return
+        }
+
+        tx.vin.forEach(({ txid, vout }) => {
+          let outpointMatches = true
+
+          if (typeof outpoint !== "undefined") {
+            const voutBuffer = Buffer.alloc(4)
+            voutBuffer.writeUIntBE(vout, 0, 4)
+
+            const actualOutpoint = Buffer.concat([
+              voutBuffer,
+              Buffer.from(txid, "hex")
+            ]).reverse()
+
+            outpointMatches =
+              actualOutpoint.compare(
+                Buffer.from(outpoint.replace("0x", ""), "hex")
+              ) === 0
           }
+
+          if (outpointMatches) {
+            transactions.push({
+              transactionID: tx.txid,
+              confirmations: tx.confirmations || 0,
+              outputPosition: matchingOutput.n,
+              value: matchingOutput.value
+            })
+          }
+        })
+      })
+
+      transactions.sort((a, b) => {
+        if (a.confirmations > b.confirmations) {
+          return 1
         }
 
-        // If neither of the above `continue`d, this is a match; return it.
-        return {
-          transactionID: tx.tx_hash,
-          outputPosition: tx.tx_pos,
-          value: tx.value
+        if (a.confirmations < b.confirmations) {
+          return -1
         }
-      }
 
-      return null
+        if (a.value > b.value) {
+          return 1
+        }
+
+        if (a.value < b.value) {
+          return -1
+        }
+
+        return 0
+      })
+
+      return transactions.length > 0 ? transactions[0] : null
     },
     /**
      * Finds all transactions to the given `receiverScript` using the

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -45,7 +45,7 @@ export const BitcoinNetwork = {
  * @property {string} transactionID Transaction ID.
  * @property {number} outputPosition Position of output in the transaction.
  * @property {number} value Value of the output (satoshis).
- * @property {number} confirmations Number of chain confirmations.
+ * @property {number} [confirmations] Number of chain confirmations (optional).
  */
 
 /**
@@ -756,11 +756,14 @@ const BitcoinHelpers = {
       })
 
       transactions.sort((a, b) => {
-        if (a.confirmations > b.confirmations) {
+        const confirmationsA = a.confirmations || 0
+        const confirmationsB = b.confirmations || 0
+
+        if (confirmationsA > confirmationsB) {
           return 1
         }
 
-        if (a.confirmations < b.confirmations) {
+        if (confirmationsA < confirmationsB) {
           return -1
         }
 

--- a/src/BitcoinHelpers.js
+++ b/src/BitcoinHelpers.js
@@ -713,7 +713,7 @@ const BitcoinHelpers = {
         })
 
         const matchingOutput = tx.vout.find(({ scriptPubKey, value }) => {
-          return scriptPubKey.hex === receiverScript && value > expectedValue
+          return scriptPubKey.hex === receiverScript && value >= expectedValue
         })
 
         if (!matchingOutput) {

--- a/src/Redemption.js
+++ b/src/Redemption.js
@@ -180,6 +180,13 @@ export default class Redemption {
           fundingOutpoint
         )
 
+        // TODO: Check if found transaction is exactly the one we expect as
+        // `signedTransaction` before we decide not to broadcast the `signedTransaction`.
+        // After fee increase it may happen that there are multiple transactions
+        // to the same script. We may want to confirm if found transaction matches
+        // the one we expect. In the previous step we're not looking via electrum
+        // for `signedTransaction` but provide parameters of the transaction such
+        // as `redeemerOutputScript`, `expectedValue` and `fundingOutpoint`.
         if (!transaction) {
           console.debug(
             `Broadcasting signed redemption transaction to Bitcoin chain ` +

--- a/src/lib/ElectrumClient.js
+++ b/src/lib/ElectrumClient.js
@@ -452,7 +452,8 @@ export default class Client {
     const transactions = await Promise.all(
       history
         .map(confirmedTx => confirmedTx.tx_hash)
-        .map(txHash => this.getTransaction(txHash))
+        // Catch error so it can proceed to other transactions from the list.
+        .map(txHash => this.getTransaction(txHash).catch(console.error))
     )
 
     return transactions

--- a/src/lib/ElectrumClient.js
+++ b/src/lib/ElectrumClient.js
@@ -453,10 +453,17 @@ export default class Client {
       history
         .map(confirmedTx => confirmedTx.tx_hash)
         // Catch error so it can proceed to other transactions from the list.
+        // This will produce a `undefined` entry in the list that we need to filter
+        // out.
         .map(txHash => this.getTransaction(txHash).catch(console.error))
     )
 
-    return transactions
+    // Filter out entries for which `getTransaction` failed in the previous step.
+    /** @type {TransactionData[]} */
+    // @ts-ignore We filtered out void entries.
+    const filteredTransactions = transactions.filter(tx => tx)
+
+    return filteredTransactions
   }
 }
 

--- a/src/lib/ElectrumClient.js
+++ b/src/lib/ElectrumClient.js
@@ -7,6 +7,7 @@ const { digest } = sha256
  * @property {string[]} addresses The addresses associated with this
  *           ScriptPubKey; one for regular ScriptPubkeys, more for multisigs.
  * @property {"pubkeyhash" | string} type The type of ScriptPubKey.
+ * @property {string} hex ScriptPubKey in hexadecimal format.
  */
 
 /**


### PR DESCRIPTION
Previously we were looking in electrum only for unspent transactions,
which seemed fine for funding but caused problems in redemption. 

There are situations on mainnet where a transaction proof has not been
submitted to the deposit yet, but the output has been spent already.
With this change, we're looking for the whole history of the script
(including mempool) and filter the results of our interest.