### PR TITLE
Fallback to querying past events in intervals on subscription error

### DIFF
--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -113,9 +113,14 @@ function getEvent(sourceContract, eventName, filter) {
     )
 
     sourceContract.once(eventName, { filter }, (error, event) => {
-      clearInterval(handle)
-      if (error) reject(error)
-      else resolve(event)
+      if (error) {
+        // We are not throwing an error as we want to fallback to querying past
+        // events in interval defined above.
+        console.warn(`failed to register for ${eventName}:`, error.message)
+      } else {
+        resolve(event)
+        clearInterval(handle)
+      }
     })
   })
 }


### PR DESCRIPTION
If there is a problem with a subscription to events we no longer reject promise and clear the interval. In case of subscription problem we want to fallback to the solution where we query past events in intervals

The change was made after testing tbtc.js `getEvent` function locally with rpc endpoint.
When subscribing to an event in `once` function a following error was returned: 
`The method eth_subscribe does not exist/is not available`. 
As a result `clearInterval` function was executed and the fallback defined in `setInterval` was never executed.