### PR TITLE
Use contracts deployment block to filter past events

### DIFF
--- a/bin/commands/deposit.js
+++ b/bin/commands/deposit.js
@@ -257,7 +257,8 @@ const commandParsers = {
           await EthereumHelpers.getExistingEvents(
             tbtc.Deposit.system(),
             "RedemptionRequested",
-            { _depositContractAddress: depositAddress }
+            { _depositContractAddress: depositAddress },
+            deposit.contract.deployedAtBlock
           )
         ).map(_ => _.returnValues._requestedFee)
 

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -41,7 +41,7 @@ class Constants {
   static async withConfig(config) {
     const { web3 } = config
     const networkId = await web3.eth.net.getId()
-    const tbtcConstantsContract = EthereumHelpers.getDeployedContract(
+    const tbtcConstantsContract = await EthereumHelpers.getDeployedContract(
       /** @type {TruffleArtifact} */ (TBTCConstantsJSON),
       web3,
       networkId.toString()

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -943,7 +943,8 @@ export default class Deposit {
     const redemptionRequest = await EthereumHelpers.getExistingEvent(
       this.factory.system(),
       "RedemptionRequested",
-      { _depositContractAddress: this.address }
+      { _depositContractAddress: this.address },
+      this.contract.deployedAtBlock
     )
 
     if (!redemptionRequest) {
@@ -1142,9 +1143,14 @@ export default class Deposit {
     // If we weren't active, wait for Funded, then mark as active.
     // FIXME/NOTE: We could be inactive due to being outside of the funding
     // FIXME/NOTE: path, e.g. in liquidation or courtesy call.
-    await EthereumHelpers.getEvent(this.factory.system(), "Funded", {
-      _depositContractAddress: this.address
-    })
+    await EthereumHelpers.getEvent(
+      this.factory.system(),
+      "Funded",
+      {
+        _depositContractAddress: this.address
+      },
+      this.contract.deployedAtBlock
+    )
     console.debug(`Deposit ${this.address} transitioned to ACTIVE.`)
 
     return true
@@ -1154,7 +1160,8 @@ export default class Deposit {
     return EthereumHelpers.getExistingEvent(
       this.factory.system(),
       "RegisteredPubkey",
-      { _depositContractAddress: this.address }
+      { _depositContractAddress: this.address },
+      this.contract.deployedAtBlock
     )
   }
 

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -203,8 +203,8 @@ export class DepositFactory {
     // Get the net_version
     const networkId = await this.config.web3.eth.net.getId()
 
-    const resolveContract = (/** @type {TruffleArtifact} */ artifact) => {
-      return EthereumHelpers.getDeployedContract(
+    const resolveContract = async (/** @type {TruffleArtifact} */ artifact) => {
+      return await EthereumHelpers.getDeployedContract(
         artifact,
         this.config.web3,
         networkId.toString()
@@ -212,39 +212,39 @@ export class DepositFactory {
     }
 
     /** @package */
-    this.constantsContract = resolveContract(
+    this.constantsContract = await resolveContract(
       /** @type {TruffleArtifact} */ (TBTCConstantsJSON)
     )
     /** @package */
-    this.systemContract = resolveContract(
+    this.systemContract = await resolveContract(
       /** @type {TruffleArtifact} */ (TBTCSystemJSON)
     )
     /** @package */
-    this.tokenContract = resolveContract(
+    this.tokenContract = await resolveContract(
       /** @type {TruffleArtifact} */ (TBTCTokenJSON)
     )
     /** @package */
-    this.depositTokenContract = resolveContract(
+    this.depositTokenContract = await resolveContract(
       /** @type {TruffleArtifact} */ (TBTCDepositTokenJSON)
     )
     /** @package */
-    this.feeRebateTokenContract = resolveContract(
+    this.feeRebateTokenContract = await resolveContract(
       /** @type {TruffleArtifact} */ (FeeRebateTokenJSON)
     )
     /** @package */
-    this.depositContract = resolveContract(
+    this.depositContract = await resolveContract(
       /** @type {TruffleArtifact} */ (DepositJSON)
     )
     /** @package */
-    this.depositFactoryContract = resolveContract(
+    this.depositFactoryContract = await resolveContract(
       /** @type {TruffleArtifact} */ (DepositFactoryJSON)
     )
     /** @package */
-    this.vendingMachineContract = resolveContract(
+    this.vendingMachineContract = await resolveContract(
       /** @type {TruffleArtifact} */ (VendingMachineJSON)
     )
     /** @package */
-    this.fundingScriptContract = resolveContract(
+    this.fundingScriptContract = await resolveContract(
       /** @type {TruffleArtifact} */ (FundingScriptJSON)
     )
   }
@@ -300,7 +300,8 @@ export class DepositFactory {
 
     return {
       depositAddress: createdEvent._depositContractAddress,
-      keepAddress: createdEvent._keepAddress
+      keepAddress: createdEvent._keepAddress,
+      createdAtBlock: createdEvent.blockNumber
     }
   }
 }
@@ -331,7 +332,8 @@ export default class Deposit {
     )
     const {
       depositAddress,
-      keepAddress
+      keepAddress,
+      createdAtBlock
     } = await factory.createNewDepositContract(satoshiLotSize)
     console.debug(
       `Looking up new deposit with address ${depositAddress} backed by ` +
@@ -341,12 +343,14 @@ export default class Deposit {
     const contract = EthereumHelpers.buildContract(
       web3,
       /** @type {TruffleArtifact} */ (DepositJSON).abi,
-      depositAddress
+      depositAddress,
+      createdAtBlock
     )
     const keepContract = EthereumHelpers.buildContract(
       web3,
       /** @type {TruffleArtifact} */ (BondedECDSAKeepJSON).abi,
-      keepAddress
+      keepAddress,
+      createdAtBlock
     )
 
     return new Deposit(factory, contract, keepContract)
@@ -359,11 +363,6 @@ export default class Deposit {
   static async forAddress(factory, depositAddress) {
     console.debug(`Looking up Deposit contract at address ${depositAddress}...`)
     const web3 = factory.config.web3
-    const contract = EthereumHelpers.buildContract(
-      web3,
-      /** @type {TruffleArtifact} */ (DepositJSON).abi,
-      depositAddress
-    )
 
     console.debug(`Looking up Created event for deposit ${depositAddress}...`)
     const createdEvent = await EthereumHelpers.getExistingEvent(
@@ -377,12 +376,20 @@ export default class Deposit {
       )
     }
 
+    const contract = EthereumHelpers.buildContract(
+      web3,
+      /** @type {TruffleArtifact} */ (DepositJSON).abi,
+      depositAddress,
+      createdEvent.blockNumber
+    )
+
     const keepAddress = createdEvent.returnValues._keepAddress
     console.debug(`Found keep address ${keepAddress}.`)
     const keepContract = EthereumHelpers.buildContract(
       web3,
       /** @type {TruffleArtifact} */ (BondedECDSAKeepJSON).abi,
-      keepAddress
+      keepAddress,
+      createdEvent.blockNumber
     )
 
     return new Deposit(factory, contract, keepContract)


### PR DESCRIPTION
We added a `deployedAtBlock` property to a contract object. The `Contract` type now extends web3's Contract Class with a field `deployedAtBlock`. The field is populated with a value reflecting the block number when the contract was deployed.

For the contracts artifacts containing a hash of the transaction when contract was deployed we use this hash to obtain block number from chain. For contracts that are deployed from factory (`Deposit` and `BondedECDSAKeep` contract), we read an event of contract creation and store block number as the deployment block number.

Previously we filtered events starting from block `0` which was overkill for requests sent to endpoints exposed on geth.
With this change we allow `fromBlock` to be passed to get events function so we filter events properly.