### PR TITLE
Export function to convert deposit state from number to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
 import TBTC, { getNetworkIdFromArtifact } from "./src/TBTC.js"
 import BitcoinHelpers from "./src/BitcoinHelpers.js"
 import EthereumHelpers from "./src/EthereumHelpers.js"
+import { nameOfState } from "./src/Deposit.js"
 
-export { BitcoinHelpers, EthereumHelpers, getNetworkIdFromArtifact }
+export {
+  BitcoinHelpers,
+  EthereumHelpers,
+  getNetworkIdFromArtifact,
+  nameOfState
+}
 
 /** @typedef { import("./src/Deposit.js").default } Deposit */
 /** @typedef { import("./src/Redemption.js").default } Redemption */

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -62,7 +62,7 @@ export const DepositStates = {
  * @return {string | null} The state name, as defined by the tbtc.js
  *         `DepositStates` enum.
  */
-function nameOfState(stateId) {
+export const nameOfState = stateId => {
   // Find the right id, then take that entry's name.
   return Object.entries(DepositStates).filter(([_, id]) => id == stateId)[0][0]
 }


### PR DESCRIPTION
The function can be used to convert numeric state values returned by the Deposit contract to a string representation of a state.