### PR TITLE
Add `block` parameter to `callWithRetry` function

### DIFF
--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -308,6 +308,8 @@ async function sendSafelyRetryable(
  * @param {Partial<SendOptions>} [sendParams] The parameters to pass to `call`.
  * @param {number} [totalAttempts=3] Total attempts which should be performed in
  *        case of an error before rethrowing it to the caller.
+ * @param {number|string} [block="latest"] Determines the block for which the
+ *        call should be performed.
  *
  * @return {Promise<any>} A promise to the result of sending the bound contract
  *         method. Fails the promise if gas estimation fails, extracting an
@@ -316,14 +318,18 @@ async function sendSafelyRetryable(
 async function callWithRetry(
   boundContractMethod,
   sendParams,
-  totalAttempts = 3
+  totalAttempts = 3,
+  block = "latest"
 ) {
   return backoffRetrier(totalAttempts)(async () => {
     // @ts-ignore A newer version of Web3 is needed to include call in TS.
-    return await boundContractMethod.call({
-      from: "", // FIXME Need systemic handling of default from address.
-      ...sendParams
-    })
+    return await boundContractMethod.call(
+      {
+        from: "", // FIXME Need systemic handling of default from address.
+        ...sendParams
+      },
+      block
+    )
   })
 }
 


### PR DESCRIPTION
Added the `block` property to the `callWithRetry` function to allow calling contract methods at a specific block in the past.