### PR TITLE
Remove unneeded async qualifier

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -203,8 +203,8 @@ export class DepositFactory {
     // Get the net_version
     const networkId = await this.config.web3.eth.net.getId()
 
-    const resolveContract = async (/** @type {TruffleArtifact} */ artifact) => {
-      return await EthereumHelpers.getDeployedContract(
+    const resolveContract = (/** @type {TruffleArtifact} */ artifact) => {
+      return EthereumHelpers.getDeployedContract(
         artifact,
         this.config.web3,
         networkId.toString()


### PR DESCRIPTION
## Problem
When running the master branch of `tbtc-dapp` with `npm start` I'm getting the following error:
```
./node_modules/@keep-network/tbtc.js/src/Deposit.js 207:13
Module parse failed: Cannot use keyword 'await' outside an async function (207:13)
File was processed with these loaders:
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
|     /** @type {TruffleArtifact} */
|     artifact => {
>       return await EthereumHelpers.getDeployedContract(artifact, this.config.web3, networkId.toString());
|     };
|     /** @package */
```

## Analysis
To be honest I'm not sure why that async function is triggering a syntax error, but the async qualifier doesn't seem to be needed since EthereumHelpers.getDeployedContract already returns a promise, so an async function that returns the awaited result is just adding a redundant wrapping to it.

## Solution
This PR turns the async function into a regular one and returns the raw promise, which achieves two goals:
- Solves the initial problem outlined in the first section
- Removes redundant code