### PR TITLE
Error handler for Deposit autoSubmit funding proof error

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -583,6 +583,34 @@ export default class Deposit {
     )
   }
 
+  // /---------------------------- Error Handler -----------------------------
+
+  /**
+   * Emits an event with an error.
+   *
+   * @param {Error} err Error to emit.
+   */
+  notifyError(err) {
+    this.eventEmitter.emit("error", err)
+  }
+
+  /**
+   * A handler that is notified whenever an error occurs.
+   *
+   * @callback OnErrorHandler
+   * @param {Error} err Error
+   */
+
+  /**
+   * Registers a handler for errors.
+   *
+   * @param {OnErrorHandler} onErrorHandler
+   *        A handler that receives an error.
+   */
+  onError(onErrorHandler) {
+    this.eventEmitter.on("error", onErrorHandler)
+  }
+
   // /---------------------------- Event Handlers -----------------------------
 
   /**
@@ -1000,8 +1028,8 @@ export default class Deposit {
     this.autoSubmittingState = {
       fundingTransaction: this.fundingTransaction,
       fundingConfirmations: this.fundingConfirmations,
-      proofTransaction: this.fundingConfirmations.then(
-        async ({ transaction, requiredConfirmations }) => {
+      proofTransaction: this.fundingConfirmations
+        .then(async ({ transaction, requiredConfirmations }) => {
           console.debug(
             `Submitting funding proof to deposit ${this.address} for ` +
               `Bitcoin transaction ${transaction.transactionID}...`
@@ -1016,8 +1044,8 @@ export default class Deposit {
             {},
             true
           )
-        }
-      )
+        })
+        .catch(this.notifyError)
     }
 
     return this.autoSubmittingState

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -432,7 +432,7 @@ export default class Deposit {
       this.publicKeyPointToBitcoinAddress(point)
     )
 
-    this.receivedFundingConfirmationEmitter = new EventEmitter()
+    this.eventEmitter = new EventEmitter()
   }
 
   // /------------------------------- Accessors -------------------------------
@@ -507,14 +507,11 @@ export default class Deposit {
           transaction.transactionID,
           requiredConfirmations,
           ({ transactionID, confirmations, requiredConfirmations }) => {
-            this.receivedFundingConfirmationEmitter.emit(
-              "receivedFundingConfirmation",
-              {
-                transactionID,
-                confirmations,
-                requiredConfirmations
-              }
-            )
+            this.eventEmitter.emit("receivedFundingConfirmation", {
+              transactionID,
+              confirmations,
+              requiredConfirmations
+            })
           }
         )
 
@@ -628,7 +625,7 @@ export default class Deposit {
    *        confirmations, and requiredConfirmations as its parameter.
    */
   onReceivedFundingConfirmation(onReceivedFundingConfirmationHandler) {
-    this.receivedFundingConfirmationEmitter.on(
+    this.eventEmitter.on(
       "receivedFundingConfirmation",
       onReceivedFundingConfirmationHandler
     )


### PR DESCRIPTION
Previously when an error was returned from `provideBTCFundingProof` transaction in the `autoSubmit` flow an `UnhandledPromiseRejectionWarning` was logged, a user of the library had no chance to handle this error.
```
UnhandledPromiseRejectionWarning: Error: execution reverted: not at current or previous difficulty
    at WebsocketSubprovider._handleSocketMessage (/e2e/node_modules/web3-provider-engine/subproviders/websocket.js:121:18)
    at WebSocket.onMessage (/e2e/node_modules/ws/lib/event-target.js:120:16)
    at WebSocket.emit (events.js:315:20)
    at Receiver.receiverOnMessage (/e2e/node_modules/ws/lib/websocket.js:720:20)
    at Receiver.emit (events.js:315:20)
    at Receiver.dataMessage (/e2e/node_modules/ws/lib/receiver.js:414:14)
    at Receiver.getData (/e2e/node_modules/ws/lib/receiver.js:346:17)
    at Receiver.startLoop (/e2e/node_modules/ws/lib/receiver.js:133:22)
    at Receiver._write (/e2e/node_modules/ws/lib/receiver.js:69:10)
    at writeOrBuffer (_stream_writable.js:352:12)
    at Receiver.Writable.write (_stream_writable.js:303:10)
    at TLSSocket.socketOnData (/e2e/node_modules/ws/lib/websocket.js:795:35)
    at TLSSocket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:302:12)
    at readableAddChunk (_stream_readable.js:278:9)
    at TLSSocket.Readable.push (_stream_readable.js:217:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23)
```

As auto submit happens asynchronously we need a way to bubble up the error. 
In this proposed approach we catch the error and emit it as an event. User is required to define error callback with `onError` function.