### PR TITLE
Update node workflow and dependencies

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,75 +1,99 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Node.js
 
 on:
   push:
-    branches: [ 'releases/**' ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
-    types: redeploy
 
 jobs:
-  build:
+  node-lint:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.11.x]
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Upgrade jq
-      run: |
-        wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-        chmod +x jq-linux64
-        sudo mv jq-linux64 /usr/bin/jq
-    - run: npm ci
-    - run: npm run lint
-    - run: npm run build --if-present
-    - run: npm test
-      env:
-        CI: true
-    - if: contains(github.ref, 'releases/ropsten')
-      name: Bump and publish npm package
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: |
-        set -x
-        name=$(jq --raw-output .name package.json)
-        version=$(jq --raw-output .version package.json)
-        preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+      - uses: actions/checkout@v2
 
-        # Find the latest published package version matching this preid.
-        # Note that in jq, we wrap the result in an array and then flatten;
-        # this is because npm show json contains a single string if there
-        # is only one matching version, or an array if there are multiple,
-        # and we want to look at an array always.
-        latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
-        latest_version=${latest_version:-$version}
-        if [ -z $latest_version ]; then
-          echo "Latest version calculation failed. Resolved info:"
-          echo "$name@$version ; preid $preid"
-          exit 1
-        fi
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-        # Update package.json with the latest published package version matching this
-        # preid to prepare for bumping.
-        echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
-        # Bump without doing any git work. Versioning is a build-time action for us.
-        # Consider including commit id? Would be +<commit id>.
-        npm version prerelease --preid=$preid --no-git-tag-version
+      - name: Install dependencies
+        run: npm ci
 
-        # Fix resolved dependency versions.
-        npm update
+      - name: Lint
+        run: npm run lint
 
-        # Publish to npm.
-        echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-        npm publish --access=public
+  node-build-test-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.11.x]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Resolve latest contracts
+        run: |
+          npm update \
+            @keep-network/keep-ecdsa \
+            @keep-network/tbtc
+
+      - name: Build node
+        run: npm run build --if-present
+
+      - name: Run tests
+        run: npm test
+
+      - name: Bump up package version
+        if: | # remove the `rfc-18` condition once workflow is tested
+          (github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request')
+            || startsWith(github.head_ref, 'rfc-18/')
+        uses: keep-network/npm-version-bump@v1
+
+      - name: Publish to npm # TODO: remove dry-run
+        if: | # remove the `rfc-18` condition once workflow is tested
+          (github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request')
+            || startsWith(github.head_ref, 'rfc-18/')
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
+          npm publish --access=public --dry-run

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -83,17 +83,15 @@ jobs:
         run: npm test
 
       - name: Bump up package version
-        if: | # remove the `rfc-18` condition once workflow is tested
-          (github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request')
-            || startsWith(github.head_ref, 'rfc-18/')
+        if: |
+          github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request'
         uses: keep-network/npm-version-bump@v1
 
-      - name: Publish to npm # TODO: remove dry-run
-        if: | # remove the `rfc-18` condition once workflow is tested
-          (github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request')
-            || startsWith(github.head_ref, 'rfc-18/')
+      - name: Publish to npm
+        if: |
+          github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request'
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --dry-run
+          npm publish --access=public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.18.2",
+  "version": "0.19.4-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -422,44 +422,679 @@
         }
       }
     },
-    "@celo/contractkit": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-0.3.8.tgz",
-      "integrity": "sha512-lEXciI3tYnDKNdyazW6etR/ZFm0wrNlX1OxNgzv5D8HCPJcFSUF3Bi4fYtL/Ocx2oHNpK4k3eDZ6aj+ZbkRC+Q==",
+    "@celo/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-CKWx0UyeYTGIQLPzcopA6Y0CDcapga0fTHod3ZVYjVlH/HsVQlm2MjSQp8iTMeLu91mPYDo581HcATlCkZ58Rg=="
+    },
+    "@celo/connect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/connect/-/connect-1.1.0.tgz",
+      "integrity": "sha512-XUIKhI6BeYYD6ZA5P09ZspuUdYIa+Cg2rGavrGaWXa03SHXpJVy9iG/NhcGC9VpNrDCeW4TdNFhEveXnnDWsrg==",
       "requires": {
-        "@celo/utils": "0.1.11",
-        "@ledgerhq/hw-app-eth": "^5.11.0",
-        "@ledgerhq/hw-transport": "^5.11.0",
+        "@celo/utils": "1.1.0",
+        "@types/debug": "^4.1.5",
+        "@types/utf8": "^2.1.6",
+        "bignumber.js": "^9.0.0",
+        "debug": "^4.1.1",
+        "utf8": "3.0.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@celo/contractkit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-1.1.0.tgz",
+      "integrity": "sha512-PgAMR71A08cZGhOICtrNj8EfYMon7PWNMQD+52X38CvfVJkg+/d56vfgbhBTHluQEhRTA/F0Y9MG3qgSUAzvDg==",
+      "requires": {
+        "@celo/base": "1.1.0",
+        "@celo/connect": "1.1.0",
+        "@celo/utils": "1.1.0",
+        "@celo/wallet-local": "1.1.0",
         "@types/debug": "^4.1.5",
         "bignumber.js": "^9.0.0",
         "cross-fetch": "3.0.4",
         "debug": "^4.1.1",
-        "eth-lib": "^0.2.8",
-        "ethereumjs-util": "^5.2.0",
         "fp-ts": "2.1.1",
         "io-ts": "2.0.1",
-        "web3": "1.2.4",
-        "web3-core": "1.2.4",
-        "web3-core-helpers": "1.2.4",
-        "web3-eth-abi": "1.2.4",
-        "web3-eth-contract": "1.2.4",
-        "web3-utils": "1.2.4"
+        "moment": "^2.29.0",
+        "web3": "1.3.4"
       },
       "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+          "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
         "@types/node": {
-          "version": "12.12.62",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "oboe": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+          "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        },
+        "swarm-js": {
+          "version": "0.1.40",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+          "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request": "^1.0.1"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4.tgz",
+          "integrity": "sha512-D6cMb2EtTMLHgdGbkTPGl/Qi7DAfczR+Lp7iFX3bcu/bsD9V8fZW69hA8v5cRPNGzXUwVQebk3bS17WKR4cD2w==",
+          "requires": {
+            "web3-bzz": "1.3.4",
+            "web3-core": "1.3.4",
+            "web3-eth": "1.3.4",
+            "web3-eth-personal": "1.3.4",
+            "web3-net": "1.3.4",
+            "web3-shh": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4.tgz",
+          "integrity": "sha512-DBRVQB8FAgoAtZCpp2GAGPCJjgBgsuwOKEasjV044AAZiONpXcKHbkO6G1SgItIixnrJsRJpoGLGw52Byr6FKw==",
+          "requires": {
+            "@types/node": "^12.12.6",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.4.tgz",
+          "integrity": "sha512-7OJu46RpCEfTerl+gPvHXANR2RkLqAfW7l2DAvQ7wN0pnCzl9nEfdgW6tMhr31k3TR2fWucwKzCyyxMGzMHeSA==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-requestmanager": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.4.tgz",
+          "integrity": "sha512-n7BqDalcTa1stncHMmrnFtyTgDhX5Fy+avNaHCf6qcOP2lwTQC8+mdHVBONWRJ6Yddvln+c8oY/TAaB6PzWK0A==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.4.tgz",
+          "integrity": "sha512-JxmQrujsAWYRRN77P/RY7XuZDCzxSiiQJrgX/60Lfyf7FF1Y0le4L/UMCi7vUJnuYkbU1Kfl9E0udnqwyPqlvQ==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.4.tgz",
+          "integrity": "sha512-V61dZIeBwogg6hhZZUt0qL9hTp1WDhnsdjP++9fhTDr4vy/Gz8T5vibqT2LLg6lQC8i+Py33yOpMeMNjztaUaw==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.4.tgz",
+          "integrity": "sha512-xriouCrhVnVDYQ04TZXdEREZm0OOJzkSEsoN5bu4JYsA6e/HzROeU+RjDpMUxFMzN4wxmFZ+HWbpPndS3QwMag==",
+          "requires": {
+            "underscore": "1.9.1",
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.3.4",
+            "web3-providers-http": "1.3.4",
+            "web3-providers-ipc": "1.3.4",
+            "web3-providers-ws": "1.3.4"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4.tgz",
+          "integrity": "sha512-drVHVDxh54hv7xmjIm44g4IXjfGj022fGw4/meB5R2D8UATFI40F73CdiBlyqk3DysP9njDOLTJFSQvEkLFUOg==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4"
+          }
+        },
+        "web3-eth": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4.tgz",
+          "integrity": "sha512-8OIVMLbvmx+LB5RZ4tDhXuFGWSdNMrCZ4HM0+PywQ08uEcmAcqTMFAn4vdPii+J8gCatZR501r1KdzX3SDLoPw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-eth-abi": "1.3.4",
+            "web3-eth-accounts": "1.3.4",
+            "web3-eth-contract": "1.3.4",
+            "web3-eth-ens": "1.3.4",
+            "web3-eth-iban": "1.3.4",
+            "web3-eth-personal": "1.3.4",
+            "web3-net": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz",
+          "integrity": "sha512-PVSLXJ2dzdXsC+R24llIIEOS6S1KhG5qwNznJjJvXZFe3sqgdSe47eNvwUamZtCBjcrdR/HQr+L/FTxqJSf80Q==",
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "underscore": "1.9.1",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4.tgz",
+          "integrity": "sha512-gz9ReSmQEjqbYAjpmAx+UZF4CVMbyS4pfjSYWGAnNNI+Xz0f0u0kCIYXQ1UEaE+YeLcYiE+ZlZdgg6YoatO5nA==",
+          "requires": {
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-utils": "1.3.4"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.4.tgz",
+          "integrity": "sha512-Fvy8ZxUksQY2ePt+XynFfOiSqxgQtMn4m2NJs6VXRl2Inl17qyRi/nIJJVKTcENLocm+GmZ/mxq2eOE5u02nPg==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "underscore": "1.9.1",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-eth-abi": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4.tgz",
+          "integrity": "sha512-b0580tQyQwpV2wyacwQiBEfQmjCUln5iPhge3IBIMXaI43BUNtH3lsCL9ERFQeOdweB4o+6rYyNYr6xbRcSytg==",
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-eth-abi": "1.3.4",
+            "web3-eth-contract": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.4.tgz",
+          "integrity": "sha512-Y7/hLjVvIN/OhaAyZ8L/hxbTqVX6AFTl2RwUXR6EEU9oaLydPcMjAx/Fr8mghUvQS3QJSr+UGubP3W4SkyNiYw==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4.tgz",
+          "integrity": "sha512-JiTbaktYVk1j+S2EDooXAhw5j/VsdvZfKRmHtXUe/HizPM9ETXmj1+ne4RT6m+950jQ7DJwUF3XU1FKYNtEDwQ==",
+          "requires": {
+            "@types/node": "^12.12.6",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-net": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-net": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4.tgz",
+          "integrity": "sha512-wVyqgVC3Zt/0uGnBiR3GpnsS8lvOFTDgWZMxAk9C6Guh8aJD9MUc7pbsw5rHrPUVe6S6RUfFJvh/Xq8oMIQgSw==",
+          "requires": {
+            "web3-core": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.4.tgz",
+          "integrity": "sha512-aIg/xHXvxpqpFU70sqfp+JC3sGkLfAimRKTUhG4oJZ7U+tTcYTHoxBJj+4A3Id4JAoKiiv0k1/qeyQ8f3rMC3g==",
+          "requires": {
+            "web3-core-helpers": "1.3.4",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.4.tgz",
+          "integrity": "sha512-E0CvXEJElr/TIlG1YfJeO3Le5NI/4JZM+1SsEdiPIfBUAJN18oOoum138EBGKv5+YaLKZUtUuJSXWjIIOR/0Ig==",
+          "requires": {
+            "oboe": "2.1.5",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.4.tgz",
+          "integrity": "sha512-WBd9hk2fUAdrbA3kUyUk94ZeILtE6txLeoVVvIKAw2bPegx+RjkLyxC1Du0oceKgQ/qQWod8CCzl1E/GgTP+MQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-shh": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4.tgz",
+          "integrity": "sha512-zoeww5mxLh3xKcqbX85irQbtFe5pc5XwrgjvmdMkhkOdZzPASlWOgqzUFtaPykpLwC3yavVx4jG5RqifweXLUA==",
+          "requires": {
+            "web3-core": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-net": "1.3.4"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
+          "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+          "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+          "requires": {
+            "bufferutil": "^4.0.1",
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "typedarray-to-buffer": "^3.1.5",
+            "utf-8-validate": "^5.0.2",
+            "yaeti": "^0.0.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        }
+      }
+    },
+    "@celo/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-FulCMswjXZZjylBV/veKQ8ESCPdfF2CBitPQL6EWinIv8UIJysQJkINjKDNBzegeHd/hDL6acXXFDv2ehmNynQ==",
+      "requires": {
+        "@celo/base": "1.1.0",
+        "@types/country-data": "^0.0.0",
+        "@types/elliptic": "^6.4.9",
+        "@types/ethereumjs-util": "^5.2.0",
+        "@types/google-libphonenumber": "^7.4.17",
+        "@types/lodash": "^4.14.136",
+        "@types/node": "^10.12.18",
+        "@types/randombytes": "^2.0.0",
+        "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
+        "bigi": "^1.1.0",
+        "bignumber.js": "^9.0.0",
+        "bip32": "2.0.5",
+        "bip39": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
+        "bls12377js": "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6",
+        "bn.js": "4.11.8",
+        "buffer-reverse": "^1.0.1",
+        "country-data": "^0.0.31",
+        "crypto-js": "^3.1.9-1",
+        "elliptic": "^6.5.4",
+        "ethereumjs-util": "^5.2.0",
+        "fp-ts": "2.1.1",
+        "google-libphonenumber": "^3.2.15",
+        "io-ts": "2.0.1",
+        "keccak256": "^1.0.0",
+        "lodash": "^4.17.14",
+        "numeral": "^2.0.6",
+        "web3-eth-abi": "1.3.4",
+        "web3-utils": "1.3.4"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+          "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@types/node": {
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+        },
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz",
+          "integrity": "sha512-PVSLXJ2dzdXsC+R24llIIEOS6S1KhG5qwNznJjJvXZFe3sqgdSe47eNvwUamZtCBjcrdR/HQr+L/FTxqJSf80Q==",
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "underscore": "1.9.1",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
+          "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        }
+      }
+    },
+    "@celo/wallet-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/wallet-base/-/wallet-base-1.1.0.tgz",
+      "integrity": "sha512-dYrWWopiBdf9J47Tgb/DvSvh6cs1mh4RytAlQgAOms/kYLJ7aTVtDvTGFQ01fUn3hyk31AmpahS6ebcf81YvRQ==",
+      "requires": {
+        "@celo/base": "1.1.0",
+        "@celo/connect": "1.1.0",
+        "@celo/utils": "1.1.0",
+        "@types/debug": "^4.1.5",
+        "@types/ethereumjs-util": "^5.2.0",
+        "bignumber.js": "^9.0.0",
+        "debug": "^4.1.1",
+        "eth-lib": "^0.2.8",
+        "ethereumjs-util": "^5.2.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -488,400 +1123,30 @@
             "safe-buffer": "^5.1.1"
           }
         },
-        "ethers": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-          "requires": {
-            "@types/node": "^10.3.2",
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.3",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "10.17.35",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
-            },
-            "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
-              }
-            }
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "scrypt-js": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-        },
-        "web3": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
-          "integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
-          "requires": {
-            "@types/node": "^12.6.1",
-            "web3-bzz": "1.2.4",
-            "web3-core": "1.2.4",
-            "web3-eth": "1.2.4",
-            "web3-eth-personal": "1.2.4",
-            "web3-net": "1.2.4",
-            "web3-shh": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-bzz": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
-          "integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
-          "requires": {
-            "@types/node": "^10.12.18",
-            "got": "9.6.0",
-            "swarm-js": "0.1.39",
-            "underscore": "1.9.1"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "10.17.35",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
-            }
-          }
-        },
-        "web3-core": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
-          "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
-          "requires": {
-            "@types/bignumber.js": "^5.0.0",
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^12.6.1",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-requestmanager": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
-          "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-eth-iban": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
-          "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-promievent": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
-          "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "eventemitter3": "3.1.2"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
-          "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4",
-            "web3-providers-http": "1.2.4",
-            "web3-providers-ipc": "1.2.4",
-            "web3-providers-ws": "1.2.4"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
-          "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
-          "requires": {
-            "eventemitter3": "3.1.2",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4"
-          }
-        },
-        "web3-eth": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
-          "integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-eth-abi": "1.2.4",
-            "web3-eth-accounts": "1.2.4",
-            "web3-eth-contract": "1.2.4",
-            "web3-eth-ens": "1.2.4",
-            "web3-eth-iban": "1.2.4",
-            "web3-eth-personal": "1.2.4",
-            "web3-net": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
-          "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
-          "requires": {
-            "ethers": "4.0.0-beta.3",
-            "underscore": "1.9.1",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
-          "integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
-          "requires": {
-            "@web3-js/scrypt-shim": "^0.1.0",
-            "any-promise": "1.3.0",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "ethereumjs-common": "^1.3.2",
-            "ethereumjs-tx": "^2.1.1",
-            "underscore": "1.9.1",
-            "uuid": "3.3.2",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-utils": "1.2.4"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-            }
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
-          "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
-          "requires": {
-            "@types/bn.js": "^4.11.4",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-promievent": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-eth-abi": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-ens": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
-          "integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
-          "requires": {
-            "eth-ens-namehash": "2.0.8",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-promievent": "1.2.4",
-            "web3-eth-abi": "1.2.4",
-            "web3-eth-contract": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
-          "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "web3-utils": "1.2.4"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
-          "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
-          "requires": {
-            "@types/node": "^12.6.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-net": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-net": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
-          "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
-          "requires": {
-            "web3-core": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
-          "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
-          "requires": {
-            "web3-core-helpers": "1.2.4",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
-          "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
-          "requires": {
-            "oboe": "2.1.4",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
-          "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
-          "requires": {
-            "@web3-js/websocket": "^1.0.29",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4"
-          }
-        },
-        "web3-shh": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
-          "integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
-          "requires": {
-            "web3-core": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-net": "1.2.4"
-          }
-        },
-        "web3-utils": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
-          "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            },
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            }
-          }
         }
       }
     },
-    "@celo/utils": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
-      "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
+    "@celo/wallet-local": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/wallet-local/-/wallet-local-1.1.0.tgz",
+      "integrity": "sha512-SJUUZTUQTYcQdBvG5rzABRWegpeiMMSzK1aaLEgqdzFLZj8moizrlNpBWvUi5qnoESWzhwWI6os4rABRc0wRVQ==",
       "requires": {
-        "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
-        "bigi": "^1.1.0",
-        "bignumber.js": "^9.0.0",
-        "bip32": "2.0.5",
-        "bip39": "3.0.2",
-        "bls12377js": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
-        "bn.js": "4.11.8",
-        "buffer-reverse": "^1.0.1",
-        "country-data": "^0.0.31",
-        "crypto-js": "^3.1.9-1",
-        "elliptic": "^6.4.1",
-        "ethereumjs-util": "^5.2.0",
-        "futoin-hkdf": "^1.0.3",
-        "google-libphonenumber": "^3.2.4",
-        "keccak256": "^1.0.0",
-        "lodash": "^4.17.14",
-        "numeral": "^2.0.6",
-        "web3-utils": "1.2.4"
+        "@celo/connect": "1.1.0",
+        "@celo/utils": "1.1.0",
+        "@celo/wallet-base": "1.1.0",
+        "@types/ethereumjs-util": "^5.2.0",
+        "eth-lib": "^0.2.8",
+        "ethereumjs-util": "^5.2.0"
       },
       "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-        },
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-        },
         "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -900,21 +1165,6 @@
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
-          }
-        },
-        "web3-utils": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
-          "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
           }
         }
       }
@@ -940,7 +1190,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
       "integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
@@ -954,7 +1203,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
       "integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -965,7 +1213,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
       "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
@@ -974,7 +1221,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
       "integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.0.7"
       }
@@ -983,7 +1229,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
       "integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
@@ -995,7 +1240,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
       "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "js-sha3": "0.5.7"
@@ -1004,14 +1248,12 @@
     "@ethersproject/logger": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
-      "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
-      "dev": true
+      "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w=="
     },
     "@ethersproject/properties": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
       "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
@@ -1020,7 +1262,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
       "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
@@ -1030,7 +1271,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
       "integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -1042,7 +1282,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
       "integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/constants": "^5.0.4",
@@ -1053,7 +1292,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
       "integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.0.4",
         "@ethersproject/bignumber": "^5.0.7",
@@ -1067,11 +1305,10 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0.tgz",
-      "integrity": "sha512-c8efKWPx5da6OSdcm9/uvdDqrfwDcYAExNqPvomhLFC0dATEEFHsr/QOAqiBm4wCZZtWMKt0dYTm5QpGtx5TXQ==",
+      "version": "1.8.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.6.tgz",
+      "integrity": "sha512-XcVCKx8LU+LWgFT6AVZ9Wz2RLt/m5mJ9ongSUeBZDZ9dy3dhaGMKdJnk12fztUcEIiHfyAINZ91UiS3HPyGQsA==",
       "requires": {
-        "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"
       },
@@ -1084,76 +1321,112 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.1.tgz",
-      "integrity": "sha512-Oz0thgLoemt/nK6dl+MONU7TEoNR3lfbnMY/Aa0oWGcwR5PlNMiBVzYY7OT4oLZIK/MxEHDOWRQAijZEQffI7g==",
+      "version": "1.7.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.8.tgz",
+      "integrity": "sha512-SqCGfW0ElBsx3iTTR/8YtHT8H6C0uPIb+P5HqD1ei5Typy+H1WUBVLjUQ6YPNraMtTGmBFmG6LUvrY7WCCTC2A==",
       "requires": {
-        "@keep-network/keep-core": "1.3.0",
-        "@keep-network/sortition-pools": "1.1.2",
+        "@keep-network/keep-core": "^1.8.0-pre.6",
+        "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0"
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.2.tgz",
-      "integrity": "sha512-bBaKyxkXDc8kJHq3qeESMrJ02m+Wbh6Uz9qUpWn8Zq3aTZaKXRZfGWT+J71OiBlAdyB4WoHZymrddWHkjImHdQ==",
+      "version": "1.2.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz",
+      "integrity": "sha512-6Tusle8KGZldO8jbFDfxChdgI6hMpTAW4LG+cAkf7jgRR48o6NkUiA7mDoWk/+dlitpHrQpWT1JM4N7aR/4/EQ==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@keep-network/tbtc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0.tgz",
-      "integrity": "sha512-V4sGR/t61PgkEF11GDZL5QNijVSdDhL7A7larcOSSCmKJOugxd5s+d+NdhYcHZhX9IS58ebtepvZan8TydHUHw==",
+      "version": "1.1.2-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-pre.0.tgz",
+      "integrity": "sha512-zfijjLLcDuK8F/brgxScA/HpESLlJl8Jvr61BC6pIhDzPDrcVaqnG2sioLZurvoJeuXf0VnISSixvWpuNLlPPQ==",
       "requires": {
-        "@keep-network/keep-ecdsa": "1.2.1",
+        "@celo/contractkit": "^1.0.2",
+        "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
         "@summa-tx/bitcoin-spv-sol": "^3.1.0",
         "@summa-tx/relay-sol": "^2.0.2",
         "openzeppelin-solidity": "2.3.0"
       }
     },
-    "@ledgerhq/devices": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.23.0.tgz",
-      "integrity": "sha512-XR9qTwn14WwN8VSMsYD9NTX/TgkmrTnXEh0pIj6HMRZwFzBPzslExOcXuCm3V9ssgAEAxv3VevfV8UulvvZUXA==",
+    "@ledgerhq/cryptoassets": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-5.48.0.tgz",
+      "integrity": "sha512-kIhZMK7DVRZ69yYXbe1ss/3DO/watVepHF3vO36/0FR+1tPRNlokq62B7B1lHia2VgZ6ysA1bysDLaLlTmKWtg==",
       "requires": {
-        "@ledgerhq/errors": "^5.23.0",
-        "@ledgerhq/logs": "^5.23.0",
-        "rxjs": "^6.6.3"
+        "invariant": "2"
+      }
+    },
+    "@ledgerhq/devices": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.48.0.tgz",
+      "integrity": "sha512-qIaL0K5Gh9kfePvptB8GGKEHGUAZuJHYmy9eDmIk6RZbgiYJ5njP/u5zQgKxijZArBgssdK/dtxEH4ueTiqkkA==",
+      "requires": {
+        "@ledgerhq/errors": "^5.48.0",
+        "@ledgerhq/logs": "^5.48.0",
+        "rxjs": "^6.6.7",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@ledgerhq/errors": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.23.0.tgz",
-      "integrity": "sha512-qtpX8aFrUUlYfOMu7BxTvxqUa8CniE+tEBpVEjYUhVbFdVJjM4ouwJD++RtQkMAU2c5jE7xb12WnUnf5BlAgLQ=="
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.48.0.tgz",
+      "integrity": "sha512-817t7M0hi7j0xY6uuG0F3kjbkaEP9hHlxfDBpb3EWkTvkg5SgHaDmvHYTjUoE1HhaPypHLjEii7URx2boOfQVA=="
     },
     "@ledgerhq/hw-app-eth": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.24.0.tgz",
-      "integrity": "sha512-DWwvFIABiAI07u4gSHhdTsClUXNXRy19dXv8WcJ2mPAphkY1FFaQ7IFxW+Mq4OcRTWWoDQkZBWQzSI2HD6YLHg==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.48.0.tgz",
+      "integrity": "sha512-HrILTZJSesi5JbdDwH3eoUs87JiZZFxK0Kyjz5bJR1cHqA8hN0ICN4t9fkwb3DOB+QwH9ch63v8tBWWwlcNIzQ==",
       "requires": {
-        "@ledgerhq/errors": "^5.23.0",
-        "@ledgerhq/hw-transport": "^5.23.0",
-        "bignumber.js": "^9.0.0",
+        "@ledgerhq/cryptoassets": "^5.48.0",
+        "@ledgerhq/errors": "^5.48.0",
+        "@ledgerhq/hw-transport": "^5.48.0",
+        "bignumber.js": "^9.0.1",
         "rlp": "^2.2.6"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
         }
       }
     },
     "@ledgerhq/hw-transport": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.23.0.tgz",
-      "integrity": "sha512-ICTG3Bst62SkC+lYYFgpKk5G4bAOxeIvptXnTLOhf6VqeN7gdHfiRzZwNPnKzI2pxmcEVbBitgsxEIEQJmDKVA==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.48.0.tgz",
+      "integrity": "sha512-fyy55GDu/UU3fxWqltF7+1PabqMzKxyiWvd1Z89DB+8ZZuz3cq0iN7ey9p4zat2YpIFonVIxKJqyYZZelzsGQA==",
       "requires": {
-        "@ledgerhq/devices": "^5.23.0",
-        "@ledgerhq/errors": "^5.23.0",
-        "events": "^3.2.0"
+        "@ledgerhq/devices": "^5.48.0",
+        "@ledgerhq/errors": "^5.48.0",
+        "events": "^3.3.0"
+      },
+      "dependencies": {
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        }
       }
     },
     "@ledgerhq/hw-transport-node-hid": {
@@ -1314,19 +1587,14 @@
       }
     },
     "@ledgerhq/logs": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.23.0.tgz",
-      "integrity": "sha512-88M8RkVHl44k6MAhfrYhx25opnJV24/2XpuTUVklID11f9rBdE+6RZ9OMs39dyX2sDv7TuzIPi5nTRoCqZMDYw=="
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.48.0.tgz",
+      "integrity": "sha512-ItOEw1BDsN7q43/uku44izA9y5f6va79KrO5SeYNcojAa3gLn6u02ADLzdHJtuvGEf9DBwCTRPlJmlT7kIaFPQ=="
     },
     "@openzeppelin/contracts": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
       "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
-    },
-    "@openzeppelin/contracts-ethereum-package": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
-      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
     },
     "@openzeppelin/upgrades": {
       "version": "2.8.0",
@@ -1351,9 +1619,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.62",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "bn.js": {
           "version": "4.11.8",
@@ -1446,9 +1714,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@solidity-parser/parser": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.1.tgz",
-      "integrity": "sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.2.tgz",
+      "integrity": "sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ=="
     },
     "@stablelib/binary": {
       "version": "0.7.2",
@@ -1509,10 +1777,546 @@
         "dotenv": "^8.2.0"
       },
       "dependencies": {
+        "@celo/contractkit": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-0.3.8.tgz",
+          "integrity": "sha512-lEXciI3tYnDKNdyazW6etR/ZFm0wrNlX1OxNgzv5D8HCPJcFSUF3Bi4fYtL/Ocx2oHNpK4k3eDZ6aj+ZbkRC+Q==",
+          "requires": {
+            "@celo/utils": "0.1.11",
+            "@ledgerhq/hw-app-eth": "^5.11.0",
+            "@ledgerhq/hw-transport": "^5.11.0",
+            "@types/debug": "^4.1.5",
+            "bignumber.js": "^9.0.0",
+            "cross-fetch": "3.0.4",
+            "debug": "^4.1.1",
+            "eth-lib": "^0.2.8",
+            "ethereumjs-util": "^5.2.0",
+            "fp-ts": "2.1.1",
+            "io-ts": "2.0.1",
+            "web3": "1.2.4",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-eth-contract": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "@celo/utils": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
+          "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
+          "requires": {
+            "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+            "bigi": "^1.1.0",
+            "bignumber.js": "^9.0.0",
+            "bip32": "2.0.5",
+            "bip39": "3.0.2",
+            "bls12377js": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+            "bn.js": "4.11.8",
+            "buffer-reverse": "^1.0.1",
+            "country-data": "^0.0.31",
+            "crypto-js": "^3.1.9-1",
+            "elliptic": "^6.4.1",
+            "ethereumjs-util": "^5.2.0",
+            "futoin-hkdf": "^1.0.3",
+            "google-libphonenumber": "^3.2.4",
+            "keccak256": "^1.0.0",
+            "lodash": "^4.17.14",
+            "numeral": "^2.0.6",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        },
+        "@umpirsky/country-list": {
+          "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+          "from": "git://github.com/umpirsky/country-list.git#05fda51"
+        },
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "bip39": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+          "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+          "requires": {
+            "@types/node": "11.11.6",
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "bls12377js": {
+          "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+          "from": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+          "requires": {
+            "@stablelib/blake2xs": "0.10.4",
+            "@types/node": "^12.11.7",
+            "big-integer": "^1.6.44",
+            "chai": "^4.2.0",
+            "mocha": "^6.2.2",
+            "ts-node": "^8.4.1",
+            "typescript": "^3.6.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
         "bn.js": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "ethers": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.56",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+              "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+            },
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+        },
+        "typescript": {
+          "version": "3.9.9",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+        },
+        "web3": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
+          "integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.4",
+            "web3-core": "1.2.4",
+            "web3-eth": "1.2.4",
+            "web3-eth-personal": "1.2.4",
+            "web3-net": "1.2.4",
+            "web3-shh": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
+          "integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.56",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+              "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
+          "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
+          "requires": {
+            "@types/bignumber.js": "^5.0.0",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-requestmanager": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
+          "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
+          "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-promievent": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
+          "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
+          "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4",
+            "web3-providers-http": "1.2.4",
+            "web3-providers-ipc": "1.2.4",
+            "web3-providers-ws": "1.2.4"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
+          "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
+          "integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-eth-accounts": "1.2.4",
+            "web3-eth-contract": "1.2.4",
+            "web3-eth-ens": "1.2.4",
+            "web3-eth-iban": "1.2.4",
+            "web3-eth-personal": "1.2.4",
+            "web3-net": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
+          "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
+          "integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
+          "requires": {
+            "@web3-js/scrypt-shim": "^0.1.0",
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
+          "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-promievent": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
+          "integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-promievent": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-eth-contract": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
+          "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
+          "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-net": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
+        "web3-net": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
+          "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
+          "requires": {
+            "web3-core": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
+          "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
+          "requires": {
+            "web3-core-helpers": "1.2.4",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
+          "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
+          "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
+          "requires": {
+            "@web3-js/websocket": "^1.0.29",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
+          "integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
+          "requires": {
+            "web3-core": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-net": "1.2.4"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
+          "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
         }
       }
     },
@@ -1554,10 +2358,23 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/country-data": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@types/country-data/-/country-data-0.0.0.tgz",
+      "integrity": "sha512-lIxCk6G7AwmUagQ4gIQGxUBnvAq664prFD9nSAz6dgd1XmBXBtZABV/op+QsJsIyaP1GZsf/iXhYKHX3azSRCw=="
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "requires": {
+        "@types/bn.js": "*"
+      }
     },
     "@types/ethereum-protocol": {
       "version": "1.0.1",
@@ -1568,6 +2385,20 @@
         "bignumber.js": "7.2.1"
       }
     },
+    "@types/ethereumjs-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+      "integrity": "sha512-qwQgQqXXTRv2h2AlJef+tMEszLFkCB9dWnrJYIdAwqjubERXEc/geB+S3apRw0yQyTVnsBf8r6BhlrE8vx+3WQ==",
+      "requires": {
+        "@types/bn.js": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/google-libphonenumber": {
+      "version": "7.4.19",
+      "resolved": "https://registry.npmjs.org/@types/google-libphonenumber/-/google-libphonenumber-7.4.19.tgz",
+      "integrity": "sha512-Rm2VhKzu4UofafuTrNTG6fy+385x1PIomnTGGSzOXGbKLpXAhNlUG+7F6UdcIosM5JMvXcJBnwUW/u4qQmt0yg=="
+    },
     "@types/hdkey": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@types/hdkey/-/hdkey-0.7.1.tgz",
@@ -1576,6 +2407,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
     "@types/node": {
       "version": "14.11.2",
@@ -1596,6 +2432,14 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
       "dev": true
     },
+    "@types/randombytes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
+      "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/react": {
       "version": "16.9.49",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
@@ -1614,6 +2458,11 @@
         "@types/node": "*"
       }
     },
+    "@types/utf8": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/utf8/-/utf8-2.1.6.tgz",
+      "integrity": "sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA=="
+    },
     "@types/web3-provider-engine": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@types/web3-provider-engine/-/web3-provider-engine-14.0.0.tgz",
@@ -1624,8 +2473,8 @@
       }
     },
     "@umpirsky/country-list": {
-      "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-      "from": "git://github.com/umpirsky/country-list.git#05fda51"
+      "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+      "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
     },
     "@web3-js/scrypt-shim": {
       "version": "0.1.0",
@@ -1880,6 +2729,11 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2052,6 +2906,14 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
     },
     "await-semaphore": {
       "version": "0.1.3",
@@ -3181,7 +4043,7 @@
         "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
         "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
         "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
-        "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+        "loady": "loady@git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
       },
       "dependencies": {
         "bufio": {
@@ -3241,9 +4103,8 @@
       }
     },
     "bip39": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
-      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "version": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
+      "from": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
       "requires": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -3281,8 +4142,8 @@
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
     "bls12377js": {
-      "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
-      "from": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+      "version": "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6",
+      "from": "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6",
       "requires": {
         "@stablelib/blake2xs": "0.10.4",
         "@types/node": "^12.11.7",
@@ -3294,14 +4155,14 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.62",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+          "version": "3.9.9",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
         }
       }
     },
@@ -3572,7 +4433,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
       "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
-      "dev": true,
       "requires": {
         "node-gyp-build": "~3.7.0"
       },
@@ -3580,8 +4440,7 @@
         "node-gyp-build": {
           "version": "3.7.0",
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
-          "dev": true
+          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
         }
       }
     },
@@ -3641,6 +4500,15 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3675,9 +4543,9 @@
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
         }
       }
     },
@@ -3776,7 +4644,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
       "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "class-is": "^1.1.0",
@@ -3789,7 +4656,6 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
           "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
           "requires": {
             "buffer": "^5.6.0",
             "varint": "^5.0.0"
@@ -3809,8 +4675,7 @@
     "class-is": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
-      "dev": true
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -4034,7 +4899,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
       "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
-      "dev": true,
       "requires": {
         "cids": "^0.7.1",
         "multicodec": "^0.5.5",
@@ -5630,7 +6494,8 @@
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -6139,6 +7004,11 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -6245,9 +7115,9 @@
       "dev": true
     },
     "futoin-hkdf": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.2.tgz",
-      "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.3.tgz",
+      "integrity": "sha512-oR75fYk3B3X9/B02Y6vusrBKucrpC6VjxhRL+C6B7FwUpuSRHbhBNG3AZbcE/xPyJmEQWsyqUFp3VeNNbA3S7A=="
     },
     "ganache-core": {
       "version": "2.11.3",
@@ -19923,6 +20793,16 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -20083,9 +20963,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.13.tgz",
-      "integrity": "sha512-USnpjJkD8St+wyshy154lF74JeauNCd8vrcusSlWjSFWitXzl7ZSuCunA/XxeVLqBv6DShrSfFMYdwGZ7x4hOw=="
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.19.tgz",
+      "integrity": "sha512-zevRvpUuc88wIXa+ijlMprAc8SrldUtYY2vQpfymmxyZ2ksct6gFrGxccpo28+zjvjK51VoSUaDUHS24XYp6dA=="
     },
     "got": {
       "version": "9.6.0",
@@ -20328,6 +21208,11 @@
           "dev": true
         }
       }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -20731,7 +21616,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -20791,14 +21675,18 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -20807,6 +21695,14 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -20903,6 +21799,11 @@
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
       "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
+    "is-generator-function": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
+      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -20959,6 +21860,11 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+    },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
@@ -21005,12 +21911,114 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
         "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-negative-zero": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+          "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "is-typedarray": {
@@ -21104,8 +22112,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -21252,25 +22259,12 @@
       }
     },
     "keccak256": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.0.tgz",
-      "integrity": "sha512-8qv2vJdQk+Aa2tFXo8zYodm+6DgXqUOqvNJhj1p1V2pxQJT1oNKxNF+zWfhtKXNLZdLvyxjB/dvd9GwcvTHSQQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
+      "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
       "requires": {
         "bn.js": "^4.11.8",
-        "keccak": "^1.4.0"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        }
+        "keccak": "^3.0.1"
       }
     },
     "keyv": {
@@ -21532,7 +22526,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -21541,6 +22534,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "ltgt": {
       "version": "2.2.1",
@@ -21986,6 +22994,11 @@
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
       "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -21995,7 +23008,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
       "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-      "dev": true,
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
@@ -22005,7 +23017,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
       "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "dev": true,
       "requires": {
         "varint": "^5.0.0"
       }
@@ -22014,7 +23025,6 @@
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
       "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "multibase": "^0.7.0",
@@ -22025,7 +23035,6 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
           "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -23348,6 +24357,7 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -24361,9 +25371,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
@@ -24608,6 +25618,24 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
+    },
     "unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -24807,7 +25835,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
       "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
-      "dev": true,
       "requires": {
         "node-gyp-build": "~3.7.0"
       },
@@ -24815,8 +25842,7 @@
         "node-gyp-build": {
           "version": "3.7.0",
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
-          "dev": true
+          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
         }
       }
     },
@@ -24824,6 +25850,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
+    "util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -24880,8 +25919,7 @@
     "varint": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=",
-      "dev": true
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "vary": {
       "version": "1.1.2",
@@ -25393,9 +26431,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
         }
       }
     },
@@ -25413,9 +26451,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.62",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "bn.js": {
           "version": "4.11.8",
@@ -25629,9 +26667,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -25655,17 +26693,17 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+              "version": "6.5.4",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
               "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
               }
             }
           }
@@ -25924,9 +26962,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.62",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "bn.js": {
           "version": "4.11.8",
@@ -26200,6 +27238,27 @@
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.2",
         "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -26274,6 +27333,18 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -26285,6 +27356,105 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true,
       "optional": true
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-negative-zero": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+          "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.18.2",
+  "version": "0.19.4-pre",
   "type": "module",
   "description": "tbtc.js provides JS bindings to the tBTC system that establishes a TBTC ERC20 token supply-pegged to BTC.",
   "repository": {
@@ -30,14 +30,14 @@
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
   "license": "MIT",
   "dependencies": {
-    "@keep-network/keep-ecdsa": "1.2.1",
-    "@keep-network/tbtc": "1.1.0",
+    "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
     "bcoin": "git+https://github.com/keep-network/bcoin.git#355c21aec91128362668162fe5a309dbc0c59c75",
     "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
     "bufio": "^1.0.6",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
-    "web3-utils": "^1.2.8",
-    "p-wait-for": "^3.1.0"
+    "p-wait-for": "^3.1.0",
+    "web3-utils": "^1.2.8"
   },
   "peerDependencies": {
     "web3": "^1.2.11",


### PR DESCRIPTION
We're updating dependencies to `keep-ecdsa` and `tbtc` to use correct
packages for building of `tbtc.js` package. At the moment we use
hardcoded values. In the future we want to make it more flexible and use
latest dependencies automatically.

This PR also changes the workflow for building node dependencies in
`tbtc.js` in order to make it consistent with changes applied in other
GH Actions workflows as part of work on RFC-18 (moving release process
from CircleCI to GitHub Actions).