### PR TITLE
Execute chain of workflows by manual triggering of upstream build

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,9 +9,22 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment for workflow execution'
+        required: false
+        default: 'dev'
+      upstream_builds:
+        description: 'Upstream builds'
+        required: false
+      ref:
+        description: 'Git reference to checkout (e.g. branch name)'
+        required: false
+        default: 'master'
 
 jobs:
   node-lint:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +61,20 @@ jobs:
       matrix:
         node-version: [12.11.x]
     steps:
+      - name: Show workflow metadata
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+            echo "Workflow dispatched on branch: ${{ github.ref }}"
+            echo "environment = ${{ github.event.inputs.environment }}"
+            echo "upstream_builds = ${{ github.event.inputs.upstream_builds }}"
+            echo "ref = ${{ github.event.inputs.ref }}"
+
+      - name: Show workflow metadata
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+            echo "ref = ${{ github.ref }}"
+            echo "sha = ${{ github.sha }}"
+
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -70,11 +97,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      - name: Get upstream packages' versions
+        uses: keep-network/upstream-builds-query@main
+        id: upstream-builds-query
+        with:
+          upstream-builds: ${{ github.event.inputs.upstream_builds }}
+          query: |
+            keep-ecdsa-solidity-version = github.com/keep-network/keep-ecdsa/solidity#version
+            tbtc-solidity-version = github.com/keep-network/tbtc/solidity#version
+
       - name: Resolve latest contracts
         run: |
-          npm update \
-            @keep-network/keep-ecdsa \
-            @keep-network/tbtc
+            npm install --save-exact \
+              @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-solidity-version }} \
+              @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-solidity-version }}
 
       - name: Build node
         run: npm run build --if-present
@@ -83,15 +119,29 @@ jobs:
         run: npm test
 
       - name: Bump up package version
-        if: |
-          github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request'
-        uses: keep-network/npm-version-bump@v1
+        if: github.event_name == 'workflow_dispatch'
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          environment: ${{ github.event.inputs.environment }}
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
 
       - name: Publish to npm
-        if: |
-          github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm publish --access=public
+      
+      - name: Notify CI about completion of the workflow
+        if: github.event_name == 'workflow_dispatch'
+        uses: keep-network/notify-workflow-completed@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/keep-network/tbtc.js"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          ref: ${{ github.event.inputs.ref }}
+          version: ${{ steps.npm-version-bump.outputs.version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.19.4-pre",
+  "version": "0.19.4-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.19.4-pre",
+  "version": "0.19.4-rc",
   "type": "module",
   "description": "tbtc.js provides JS bindings to the tBTC system that establishes a TBTC ERC20 token supply-pegged to BTC.",
   "repository": {


### PR DESCRIPTION
This PR is part of a bigger work, spanning multiple repositories.
The main purpose of the work is to automate the process of workflows`
executions during product deployment, so that the workflows would be
triggered in a particular logical order and at the correct moment. By
that we mean:
* workflows requiring the presence of artifacts created by other
  workflows would not start before those upstream workflows are
  finished
* successfully executed workflows would automatically kick-off
  downstream workflows specified in the config file
* if any workflow in that chain of executions fails, the downstream
  workflows will not be triggered

To achieve the above requirements, following changes were introduced:
* A repository (called `ci`) managing the order of workflow executions
  was created
* The `config/config.json` file in `ci` repo describes the
  upstream/downstream relations between product modules and workflows
* The `Main` GH Actions workflow in `ci` repo allows for manual
  triggering of workflow deploying specified module, by providing the
  details of its upstream builds (to trigger deploy of the most
  upstream module, `Main` must be triggered with empty
  `upstream_builds` input)
* The triggering of module workflows by the `ci`'s `Main` workflow
  happens thanks to a `keep-network/run-workflow` action working as an
  intermediary (`Main` calls the `run-workflow`, which triggers
  workflow deploying the specified module)
* All NPM modules built as a part of the release process get versioned
  with `<base-version>-<environment>.<build-number>+<branch>.<commit>`
  version (thanks to `keep-network/upstream-builds-query` action that
  reads versions of older deployments and thanks to
  `keep-network/npm-version-bump@v2` action that bumps-up the version
  of the new artifact)
  (note: tagging of artifacts and versioning of docker images will be
  done at the later stage, outside this PR)
* Deployment workflows that are about to successfully finish will be
  executing the `keep-network/notify-workflow-completed` action as the
  last step - the action will then trigger the `ci`'s `Main` workflow
  with appropriate inputs
* Module workflows configuration has been adjusted to support the above
  features
* Conditions of execution of particular jobs/steps have been modified
  - after the changes contracts migration and deployments of artifacts
  happens only for workflows triggered by the `workflow-dispatch`
  event; actions like linting and sec scans are no longer executed for
  workflows triggered by `workflow-dispatch`
* Additionally, a couple of other changes were introduced to improve
  the process of build management:
  - listing of workflow metadata
  - unification of workflows' code
  
REF:
https://github.com/keep-network/keep-core/pull/2453
https://github.com/keep-network/keep-ecdsa/pull/777
https://github.com/keep-network/tbtc/pull/791
https://github.com/keep-network/tbtc-dapp/pull/394