### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,7 +6,7 @@ name: Node.js
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
     inputs:
@@ -20,7 +20,7 @@ on:
       upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
-        default: 'master'
+        default: 'main'
 
 jobs:
   node-lint:

--- a/README.adoc
+++ b/README.adoc
@@ -180,7 +180,7 @@ and `src/Redemption.js` (until more details are filled in here...).
 
 Handles to the Ethereum `TruffleContract` instances are directly available on
 the `tbtc.Deposit` object. Here is how these map to Solidity files in the
-https://github.com/keep-network/tbtc/tree/master[tBTC repository]:
+https://github.com/keep-network/tbtc/tree/main[tBTC repository]:
 
 * `tbtc.Deposit.system()`: `TBTCSystem.sol`
 * `tbtc.Deposit.depositFactory()`: `DepositFactory.sol`


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
After the proposed changes get merged to the `master` branch, the
repository should be ready for the migration from `master` to `main`.

To migrate from `master` to `main`:
1. Do a local branch rename with `git branch -m master main`
2. Push the renamed branch `git push -u origin main`
3. In the Github repo settings, rename the default branch: Settings ->
    Branches -> Default branch -> (pencil icon) -> (change `master` to
    `main`) -> (approve)

After migration other contributors should update their local repositories:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Refs:
https://github.com/keep-network/keep-core/pull/2521
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc/pull/810
https://github.com/keep-network/tbtc-dapp/pull/399
https://github.com/keep-network/keep-common/pull/79
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/local-setup/pull/97
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3
https://github.com/keep-network/load-env-variables/pull/2