### PR TITLE
Add environment tag during npm publish

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -126,7 +126,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public
+          npm publish --access=public --tag ${{ github.event.inputs.environment }}
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
This change adds an additional environment tag for packages published during the `Publish to npm` step. This adds a convenient reference to the latest versions of the `tbtc.js` package for each environment.