### PR TITLE
Update electrum-client-js dependency to v0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,8 +5330,8 @@
       "dev": true
     },
     "electrum-client-js": {
-      "version": "git+https://github.com/keep-network/electrum-client-js.git#6bdc216da4228460b6e28706220c70a873f9084d",
-      "from": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
+      "version": "git+https://github.com/keep-network/electrum-client-js.git#8eccf443ca69ab5d81315016057ae9b1ae5818bf",
+      "from": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
       "requires": {
         "websocket": "^1.0.29"
       }
@@ -26494,13 +26494,15 @@
       }
     },
     "websocket": {
-      "version": "1.0.29",
-      "resolved": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
       "requires": {
+        "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
         "es5-ext": "^0.10.50",
-        "nan": "^2.14.0",
         "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
         "yaeti": "^0.0.6"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bcoin": "git+https://github.com/keep-network/bcoin.git#355c21aec91128362668162fe5a309dbc0c59c75",
     "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
     "bufio": "^1.0.6",
-    "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
+    "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
     "p-wait-for": "^3.1.0",
     "web3-utils": "^1.2.8"
   },


### PR DESCRIPTION
The electrum-client-js version v0.1.1 has a fix for TLS protocol
support.