### PR TITLE
Bump up tbtc.js version to `0.19.5-pre` in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.19.4-pre",
+  "version": "0.19.5-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.19.4-pre",
+  "version": "0.19.5-pre",
   "type": "module",
   "description": "tbtc.js provides JS bindings to the tBTC system that establishes a TBTC ERC20 token supply-pegged to BTC.",
   "repository": {


### PR DESCRIPTION
The `0.19.4` version of `tbtc.js` package has been published. We now
need to bump-up package verson to `0.19.5-pre`.