### PR TITLE
Updates to error notifications

### DIFF
--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -1045,7 +1045,7 @@ export default class Deposit {
             true
           )
         })
-        .catch(this.notifyError)
+        .catch(err => this.notifyError(err))
     }
 
     return this.autoSubmittingState

--- a/src/Deposit.js
+++ b/src/Deposit.js
@@ -424,6 +424,8 @@ export default class Deposit {
     this.keepContract = keepContract
     this.contract = depositContract
 
+    this.eventEmitter = new EventEmitter()
+
     // Set up state transition promises.
     this.activeStatePromise = this.waitForActiveState()
 
@@ -431,8 +433,6 @@ export default class Deposit {
     this.bitcoinAddress = this.publicKeyPoint.then(point =>
       this.publicKeyPointToBitcoinAddress(point)
     )
-
-    this.eventEmitter = new EventEmitter()
   }
 
   // /------------------------------- Accessors -------------------------------


### PR DESCRIPTION
This PR updates the way we use `notifyError` function in catch block to fix [`UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'eventEmitter' of undefined` error](https://github.com/keep-network/local-setup/pull/98/checks?check_run_id=3254058470)