### PR TITLE
Adding cron for daily tests and builds for Meercode

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,6 +4,8 @@
 name: Node.js
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
@@ -24,7 +26,9 @@ on:
 
 jobs:
   node-lint:
-    if: github.event_name != 'workflow_dispatch'
+    if: | 
+      github.event_name != 'workflow_dispatch'
+        && github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.