### PR TITLE
Check if transaction exists before getting blockNumber

### DIFF
--- a/src/EthereumHelpers.js
+++ b/src/EthereumHelpers.js
@@ -399,11 +399,16 @@ async function getDeployedContract(artifact, web3, networkId) {
     artifact.networks[networkId].transactionHash
   )
 
+  let deployedAtBlock
+  if (transaction && transaction.blockNumber) {
+    deployedAtBlock = transaction.blockNumber
+  }
+
   return buildContract(
     web3,
     artifact.abi,
     deploymentInfo.address,
-    transaction.blockNumber || undefined
+    deployedAtBlock
   )
 }
 


### PR DESCRIPTION
It may happen that `web3.eth.getTransaction` fails to get a transaction details for ancient (a year old😉) transactions (see:
https://github.com/ethereum/go-ethereum/issues/23569).

Currently, in such a situation, the execution breaks with `Cannot read property 'blockNumber' of null`.

Here we fix the resolution of the block number by checking if the transaction is not null.