### PR TITLE
Use `-dev` suffix in the versioning of the npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.19.5-pre",
+  "version": "0.19.5-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc.js",
-  "version": "0.19.5-pre",
+  "version": "0.19.5-dev",
   "type": "module",
   "description": "tbtc.js provides JS bindings to the tBTC system that establishes a TBTC ERC20 token supply-pegged to BTC.",
   "repository": {


### PR DESCRIPTION
We've recently added an NPM workflow which publishes npm packages meant
for development environment and versioned using `-dev.X` suffix. For
consistency we should also use `-dev` suffix in the `package.json` and
`package-lock.json`.