### PR TITLE
Don't use unauthenticated git protocol

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Resolve latest contracts
         if: github.event_name != 'workflow_dispatch'
         run: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Resolve latest contracts
         run: |
           npm update --save-exact \

--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,18 @@ been a release.
 
 API stability is not guaranteed, but the API is likely ~90% complete.
 
+*NOTE:* The `tbtc.js` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package or
+update of its dependencies using NPM may result in `The unauthenticated git
+protocol on port 9418 is no longer supported` error. +
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+```
+git config --global url."https://".insteadOf git://
+```
+
 == Usage
 
 You need two things to use `tbtc.js`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3991,7 +3991,7 @@
           "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
           "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
           "requires": {
-            "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+            "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
             "bigi": "^1.1.0",
             "bignumber.js": "^9.0.0",
             "bip32": "2.0.5",
@@ -4797,8 +4797,8 @@
       }
     },
     "@umpirsky/country-list": {
-      "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-      "from": "git://github.com/umpirsky/country-list.git#05fda51"
+      "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+      "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",


### PR DESCRIPTION
GitHub is no longer allowing for referencing the dependencies using
`git://` protocol. Instead we can use `git+https://`.
WIthout the change, `npm ci` executed in GitHub Actions workflows
results with ` The unauthenticated git protocol on port 9418 is no
longer supported.` error.
More info:
https://github.blog/2021-09-01-improving-git-protocol-security-github/.

We've already introduced a fix for this issue couple of months ago in
PR #144, but the change got accidentally overwritten by PR #146.